### PR TITLE
Change the name of PhotonVisibilityService

### DIFF
--- a/duneopdet/PhotonPropagation/photpropservices_dune.fcl
+++ b/duneopdet/PhotonPropagation/photpropservices_dune.fcl
@@ -243,7 +243,7 @@ dune10kt_1x2x6_refl_photonvisibilityservice_buildlib.LibraryFile:      "PhotonPr
 # DUNE VD #
 ######################
 
-dune10kt_vd_1x8x14_photonvisibilityservice_ArXe: 
+dune10kt_vd_photonvisibilityservice_ArXe: # Generated using 1x8x14 geometry. 
 {
   # hybrid library
   NX: 85


### PR DESCRIPTION
Change the name from `dune10kt_vd_1x8x14_photonvisibilityservice_ArXe` to `dune10kt_vd_photonvisibilityservice_ArXe` so it would not cause confusion when including in the general simulation service and added a comment to explain this PhotonVisibilityService is trained for 1x8x14 geometry. 