### PR TITLE
Put the protodune_pdfastsim_pvs back.

### DIFF
--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -83,7 +83,14 @@ dunevd_pdfastsim_pvs_external.SimulationLabel: IonAndScintExternal
 dunevd_pdfastsim_pvs_external.ScintTimeTool:  @local::ScintTimeXeDoping10ppm
 dunevd_pdfastsim_pvs_external.VUVTiming:	  @local::dunevd_xe_timing_geo
 
+#############
+# ProtoDUNE #
+#############
 
+protodune_pdfastsim_pvs:                       @local::standard_pdfastsim_pvs
+protodune_pdfastsim_pvs.SimulationLabel:       "IonAndScint:priorSCE"
+
+ 
 ################
 # ProtoDUNE-HD #
 ################


### PR DESCRIPTION
I put `protodune_pdfastsim_pvs` back since I `protodune_hd_pdfastsim_par` and `protodune_hd_pdfastsim_pvs_external` separately. And also CI is failing without `protodune_pdfastsim_pvs`