### PR TITLE
Enabling xenon absorption length

### DIFF
--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -78,7 +78,8 @@ dunevd_pdfastsim_par_xe.IncludePropTime:       true
 dunevd_pdfastsim_par_xe.GeoPropTimeOnly:       true			  # Xe propoagation time geometric approximation
 dunevd_pdfastsim_par_xe.VUVTiming:             @local::dunevd_xe_timing_geo
 dunevd_pdfastsim_par_xe.ScintTimeTool:         @local::ScintTimeXeDoping10ppm
-dunevd_pdfastsim_par_xe.OnlyActiveVolume: 	   true
+dunevd_pdfastsim_par_xe.OnlyActiveVolume:      true
+dunevd_pdfastsim_par_xe.UseXeAbsorption:       true
 
 # External region for laterals (Hybrid model)
 dunevd_pdfastsim_pvs_external: 					  @local::standard_pdfastsim_pvs


### PR DESCRIPTION
This PR enables the xenon wavelength photon absorption length (80m) in the semi-analytical model for DUNE-VD. This PR requires:

https://github.com/LArSoft/larsim/pull/115
https://github.com/LArSoft/lardataalg/pull/39
