### PR TITLE
Deconvolution & OphitFinder updates for upcoming mc production

### DIFF
--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
@@ -6,16 +6,15 @@ BEGIN_PROLOG
 
 WfmWienerfilter: {
     Name: "Wiener"
-    Cutoff: 0.1      # Cutoff is not used in this filter
+    Cutoff: 1.      # Cutoff is not used in this filter
 }
   
 WfmGaussfilter: {
     Name: "Gauss"
-    Cutoff: 1.       # In MHz.The cutoff frequency is defined by the standard deviation in the frequency domain.
+    Cutoff: 0.13     # In MHz.The cutoff frequency is defined by the standard deviation in the frequency domain.
 }                    # The cutoff value should be changed if signal smoothing is not observed.
  
 ###################################################################
-
 
 dune_deconvolution:
 {
@@ -25,40 +24,32 @@ dune_deconvolution:
  
   #The LineNoiseRMS,PreTrigger,Pedestal, Samples and DigiDataFile below have the same values as the Digitizer.
 
-  LineNoiseRMS:      3        # Pedestal RMS in [ADC] counts, likely an underestimate
+  LineNoiseRMS:      2.6      # Pedestal RMS in [ADC] counts, likely an underestimate
   PreTrigger:        100      # In [ticks] 
   Pedestal:          1500     # In [ADC]
   Samples:           1000     # Timewindow (ReadoutWindow) in [ticks]
   Scale:             1        # Scaling of resulting deconvolution signal.
-  DigiDataColumn:     0       # SPE template source file column.                     
+  DigiDataColumn:    0        # SPE template source file column.                     
   DigiDataFile:      "SPE_DAPHNE2_FBK_2022.dat"    
                      # The SPE template with undershoot and without pretrigger (in ADC*us), 
-                     # was obtained from DAPHNE V2 and the cold amplifier (with 48 SiPM FBK/HPK).
   
-  AutoScale:             true   # Scaling based on SPE amplitude from template (Use "true" for Wiener Filter and
-                                # "false" for Gauss Filter). If set to false the value of Scale is used.
-  ApplyPostBLCorrection: true   # Correct baseline after the deconvolution process.
-  PedestalBuffer:         20    # In [ticks], should always be smaller than PreTrigger.
-  
-  ApplyPostfilter:       true   # Filter the waveforms after deconvolution.
+  AutoScale:             true    # Scaling based on SPE amplitude from template (Use "true" for Wiener Filter and
+                                 # "false" for Gauss Filter). If set to false the value of Scale is used.
+  ApplyPostBLCorrection: false   # Correct baseline after the deconvolution process(Use "false" for Wiener).
+  PedestalBuffer:        20      # In [ticks], should always be smaller than PreTrigger.
+  ApplyPostfilter:       true    # Filter the waveforms after "Wiener" deconvolution.
   
   WfmFilter: @local::WfmWienerfilter     # Write the filter: "WfmWienerfilter" or "WfmGaussfilter"
-  WfmPostfilter: @local::WfmGaussfilter  # Only available "Gauss" postfilter.
-       
+  # If gauss filter is used, the following parameters should be changed:
+  #WfmGaussfilter.Cutoff: 0.13; AutoScale: false; Scale: 1.; ApplyPostBLCorrection: true; ApplyPostfilter: false;
+  WfmPostfilter: @local::WfmGaussfilter  # Only available "Gauss" postfilter. 
 }
-
- #DataFile hpk
- dune_deconvolution_hpk: @local::dune_deconvolution
- dune_deconvolution_hpk.SPEDataFile: "SPE_DAPHNE2_HPK_2022.dat"
  
- #Postfilter Cutoff 
- dune_deconvolution.WfmPostfilter.Cutoff: 2.8     # Use this value only for postfilter.
- 
- #By debbuging and review the values (SNR,H,S,N,G0,G1,G,V,v) of the Wiener filter:
- deconvolution_snr: @local::dune_deconvolution
- deconvolution_snr.OutputProduct: "SNR"
+#Postfilter Cutoff 
+dune_deconvolution.WfmPostfilter.Cutoff: 1.8     # Use this value only for postfilter.
 
+#By debbuging and review the values (SNR,H,S,N,G0,G1,G,V,v) of the Wiener filter:
+deconvolution_snr: @local::dune_deconvolution
+deconvolution_snr.OutputProduct: "SNR"
 
 END_PROLOG
-  
-  

--- a/duneopdet/OpticalDetector/OpHitFinder/CMakeLists.txt
+++ b/duneopdet/OpticalDetector/OpHitFinder/CMakeLists.txt
@@ -1,0 +1,85 @@
+art_make( BASENAME_ONLY ALLOW_UNDERSCORES
+                LIBRARY_NAME duneopdet_OpticalDetector_OpHitFinder
+                LIB_LIBRARIES 
+                                lardataobj::RecoBase
+                                larcorealg::Geometry
+                                larcore::Geometry_Geometry_service
+                                larana::OpticalDetector_OpHitFinder
+                                #duneopdet::OpticalDetector_OpHitFinder
+                                nusimdata::SimulationBase
+                                fhiclcpp::fhiclcpp
+                                messagefacility::MF_MessageLogger
+                                art::Framework_Core
+                                art::Framework_Principal
+                                art::Framework_Services_Registry
+                                art_root_io::tfile_support
+                                ROOT::Core
+                                art_root_io::TFileService_service
+                                art::Framework_Services_Optional_RandomNumberGenerator_service
+                                art::Persistency_Common
+                                art::Utilities 
+				canvas::canvas
+                                cetlib::cetlib 
+				cetlib_except::cetlib_except 
+                                ROOT_BASIC_LIB_LIST
+                                Boost::filesystem
+  
+                MODULE_LIBRARIES
+                                dunecore::DuneObj
+                                lardataalg::DetectorInfo
+                                lardataobj::RecoBase
+                                larana::OpticalDetector
+                                larana::OpticalDetector_OpHitFinder
+                                larcorealg::Geometry
+                                larcore::Geometry_Geometry_service
+                                duneopdet::OpticalDetector
+                                duneopdet::OpticalDetector_OpHitFinder
+                                larsim::MCCheater_ParticleInventoryService_service
+                                larsim::MCCheater_PhotonBackTrackerService_service 
+                                nusimdata::SimulationBase
+                                nurandom::RandomUtils_NuRandomService_service
+                                fhiclcpp::fhiclcpp
+                                messagefacility::MF_MessageLogger
+                                art::Framework_Core
+                                art::Framework_Principal
+                                art::Framework_Services_Registry
+                                art_root_io::tfile_support
+                                ROOT::Core
+                                art_root_io::TFileService_service
+                                art::Framework_Services_Optional_RandomNumberGenerator_service
+                                art::Persistency_Provenance
+                                art::Persistency_Common
+                                art::Utilities 
+				canvas::canvas
+                                cetlib::cetlib 
+				cetlib_except::cetlib_except
+                                CLHEP
+                                ROOT_BASIC_LIB_LIST
+                                Boost::filesystem
+
+                SERVICE_LIBRARIES
+                                larcorealg::Geometry
+                                larcore::Geometry_Geometry_service
+                                duneopdet::OpticalDetector
+                                duneopdet::OpticalDetector_OpHitFinder
+                                fhiclcpp::fhiclcpp
+                                messagefacility::MF_MessageLogger
+                                art::Framework_Core
+                                art::Framework_Principal
+                                art::Framework_Services_Registry
+                                art_root_io::tfile_support
+                                ROOT::Core
+                                art_root_io::TFileService_service
+                                art::Persistency_Common
+                                art::Utilities 
+				canvas::canvas
+                                cetlib::cetlib cetlib_except
+                                CLHEP
+                                ROOT_BASIC_LIB_LIST                                
+                                Boost::filesystem
+
+)
+
+install_headers()
+install_fhicl()
+install_source()

--- a/duneopdet/OpticalDetector/OpHitFinder/OpFlashAnaDeco.fcl
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpFlashAnaDeco.fcl
@@ -3,7 +3,7 @@ BEGIN_PROLOG
 dune_opflashana_deco:
 {
      
-  module_type:           "OpFlashAna_Deco"
+  module_type:           "OpFlashAnaDeco"
   OpFlashModuleLabel:    "opflash"   #opflashfinder module
   OpHitModuleLabel:      "ophitspe"  #ophitfinder module
   InputrecobOpflash:     "false"     # Write "true" if the input includes recob::OpFlash

--- a/duneopdet/OpticalDetector/OpHitFinder/OpFlashAnaDeco_module.cc
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpFlashAnaDeco_module.cc
@@ -1,5 +1,5 @@
 // ===============================================================
-// OpFlashAna_Deco_module.cc
+// OpFlashAnaDeco_module.cc
 // This module is based on the larana/OpFlashAna_module.cc.  
 // This analyzer writes out a TTree containing the properties of
 // each reconstructed ophit and opflash
@@ -10,8 +10,8 @@
 // each reconstructed flash
 //
 
-#ifndef OpFlashAna_Deco_h
-#define OpFlashAna_Deco_h
+#ifndef OpFlashAnaDeco_h
+#define OpFlashAnaDeco_h
 
 // ROOT includes
 #include "TH1.h"
@@ -41,10 +41,10 @@
 
 namespace opdet {
 
-  class OpFlashAna_Deco : public art::EDAnalyzer {
+  class OpFlashAnaDeco : public art::EDAnalyzer {
   public:
     // Standard constructor and destructor for an ART module.
-    OpFlashAna_Deco(const fhicl::ParameterSet&);
+    OpFlashAnaDeco(const fhicl::ParameterSet&);
 
     // The analyzer routine, called once per event.
     void analyze(const art::Event&);
@@ -131,13 +131,13 @@ namespace opdet {
 
   //-----------------------------------------------------------------------
   // Constructor
-  OpFlashAna_Deco::OpFlashAna_Deco(fhicl::ParameterSet const& pset) : EDAnalyzer(pset)
+  OpFlashAnaDeco::OpFlashAnaDeco(fhicl::ParameterSet const& pset) : EDAnalyzer(pset)
   {
 
     // Indicate that the Input Module comes from .fcl
     fOpFlashModuleLabel = pset.get<std::string>("OpFlashModuleLabel");
     fOpHitModuleLabel = pset.get<std::string>("OpHitModuleLabel");
-    fInputrecobOpflash = pset.get<std::string>("InputrecobOpflash",true);
+    fInputrecobOpflash = pset.get<std::string>("InputrecobOpflash");
     
     auto const clock_data =
       art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
@@ -258,7 +258,7 @@ namespace opdet {
   }
 
   //-----------------------------------------------------------------------
- void OpFlashAna_Deco::analyze(const art::Event& evt)
+ void OpFlashAnaDeco::analyze(const art::Event& evt)
   {
   
   // Access ART's TFileService, which will handle creating and writing
@@ -443,5 +443,5 @@ namespace opdet {
 } // namespace opdet
 
 namespace opdet {
-  DEFINE_ART_MODULE(OpFlashAna_Deco)
+  DEFINE_ART_MODULE(OpFlashAnaDeco)
 }

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco.fcl
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco.fcl
@@ -10,7 +10,7 @@ dune_ophit_finder_deco:
     
     InputDigiType:   "recob" # Write recob for OpWaveform object raw OpDetWaveform object
     ChannelMasks:    []      # Will ignore channels in this list
-    HitThreshold:    10.0     # Amplitude threshold for hits "25.0 for Gauss" and "10.0 for Wiener" 
+    HitThreshold:    3.0     # Amplitude threshold for hits "5.0 for Gauss" and "2.0 for Wiener" 
     UseCalibrator:   false   # If set to false, SPE parameters below
                              # are used. If set to true, is it unusable? 
     AreaToPE:        true    # Use area to calculate number of PEs
@@ -22,19 +22,22 @@ dune_ophit_finder_deco:
     PedAlgoPset:     @local::standard_algo_pedestal_edges      
     HitAlgoPset:{
         Name: "SlidingWindow"     #This setting changes according to the filter used.
-        ADCThreshold:        10     
+        ADCThreshold:        3.0     
         NSigmaThreshold:     1     
-        EndADCThreshold:     10     
+        EndADCThreshold:     1     
         EndNSigmaThreshold:  1     
         MinPulseWidth:       1
-        NumPreSample:        3
-        NumPostSample:       6
+        NumPreSample:        2
+        NumPostSample:       2
         PositivePolarity:    true
-        TailADCThreshold:    10
+        TailADCThreshold:    1
         TailNSigmaThreshold: 1
         Verbosity:           false
     }   
 }
 
+dune_ophit_finder_gauss_deco: @local::dune_ophit_finder_deco
+dune_ophit_finder_gauss_deco.HitThreshold: 5.0
+dune_ophit_finder_gauss_deco.HitAlgoPset.ADCThreshold: 5.0
 
 END_PROLOG

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco.fcl
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco.fcl
@@ -10,7 +10,7 @@ dune_ophit_finder_deco:
     
     InputDigiType:   "recob" # Write recob for OpWaveform object raw OpDetWaveform object
     ChannelMasks:    []      # Will ignore channels in this list
-    HitThreshold:    3.0     # Amplitude threshold for hits "5.0 for Gauss" and "2.0 for Wiener" 
+    HitThreshold:    3.0     # Amplitude threshold for hits "5.0 for Gauss" and "3.0 for Wiener" 
     UseCalibrator:   false   # If set to false, SPE parameters below
                              # are used. If set to true, is it unusable? 
     AreaToPE:        true    # Use area to calculate number of PEs

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitFinder_deco_run.fcl
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitFinder_deco_run.fcl
@@ -2,7 +2,7 @@
 #include "opticaldetectorservices_dune.fcl"
 #include "services_dune.fcl"
 #include "OpHitFinderDeco.fcl"
-#include "OpFlashAna_Deco.fcl"
+#include "OpFlashAnaDeco.fcl"
 #include "tools_dune.fcl"
 
 process_name: Reco


### PR DESCRIPTION
The changes made to the fcl files propose an optimized PDS reco workflow up to OpHit level.
The default is Deconvolution with wiener + gauss filters and OpHitFinder using the slidingwindow algorithm.
Parameters have been optimized in the range of 20MeV - 3GeV. 