### PR TITLE
ADD COUSTOM OPHITFINDER TO PATH

### DIFF
--- a/duneopdet/OpticalDetector/CMakeLists.txt
+++ b/duneopdet/OpticalDetector/CMakeLists.txt
@@ -87,3 +87,4 @@ install_fhicl()
 install_source()
 
 add_subdirectory(Deconvolution)
+add_subdirectory(OpHitFinder)


### PR DESCRIPTION
Missing addsubfolder to cmake required to include deconvolution and ophit steps in standard reco workflow