### PR TITLE
New photon library based on protoDUNEhd_v6

### DIFF
--- a/duneopdet/PhotonPropagation/photpropservices_dune.fcl
+++ b/duneopdet/PhotonPropagation/photpropservices_dune.fcl
@@ -499,6 +499,28 @@ protodune_hd_v6_photonvisibilityservice:  #generated using v6 geometry, 1m RSL, 
   LibraryFile: "PhotonPropagation/LibraryData/libext_protodunehd_v6_Ar_Baseline_v09_69_00d00_5e7_25x25x25_landau_20231216.root"    
 }
 
+protodune_hd_TBC_photonvisibilityservice: # Generated using protoDUNEhd_v6_refactored geometry.
+{
+  # hybrid library
+  NX: 94
+  NY: 87
+  NZ: 78
+
+  UseCryoBoundary: false
+  DoNotLoadLibrary: false
+  LibraryBuildJob: false
+  #IncludePropTime: true
+
+  LibraryFile: "PhotonPropagation/LibraryData/TBC"
+
+  XMin: -391.564606
+  XMax: 464.195190
+  YMin: -65.479393
+  YMax: 725.724670
+  ZMin: -199.330917
+  ZMax: 661.863403
+}
+
 ################
 # ProtoDUNE-VD #
 ################

--- a/duneopdet/PhotonPropagation/photpropservices_dune.fcl
+++ b/duneopdet/PhotonPropagation/photpropservices_dune.fcl
@@ -499,7 +499,7 @@ protodune_hd_v6_photonvisibilityservice:  #generated using v6 geometry, 1m RSL, 
   LibraryFile: "PhotonPropagation/LibraryData/libext_protodunehd_v6_Ar_Baseline_v09_69_00d00_5e7_25x25x25_landau_20231216.root"    
 }
 
-protodune_hd_v6_optimised_photonvisibilityservice: # Generated using protoDUNEhd_v6_refactored geometry.
+protodune_hd_v6_hybridModel_photonvisibilityservice: # Generated using protoDUNEhd_v6_refactored geometry.
 {
   # Generated with
   # Rayleigh scattering length, 99.9cm @ 128nm

--- a/duneopdet/PhotonPropagation/photpropservices_dune.fcl
+++ b/duneopdet/PhotonPropagation/photpropservices_dune.fcl
@@ -499,19 +499,26 @@ protodune_hd_v6_photonvisibilityservice:  #generated using v6 geometry, 1m RSL, 
   LibraryFile: "PhotonPropagation/LibraryData/libext_protodunehd_v6_Ar_Baseline_v09_69_00d00_5e7_25x25x25_landau_20231216.root"    
 }
 
-protodune_hd_TBC_photonvisibilityservice: # Generated using protoDUNEhd_v6_refactored geometry.
+protodune_hd_v6_optimised_photonvisibilityservice: # Generated using protoDUNEhd_v6_refactored geometry.
 {
-  # hybrid library
-  NX: 94
-  NY: 87
-  NZ: 78
+  # Generated with
+  # Rayleigh scattering length, 99.9cm @ 128nm
+  # services.LArPropertiesService.AbsLengthSpectrum: [2000,2000,2000,8000,8000,8000,2000,2000,2000,2000]
+  # Reflectivities ON.
 
   UseCryoBoundary: false
   DoNotLoadLibrary: false
   LibraryBuildJob: false
   #IncludePropTime: true
 
-  LibraryFile: "PhotonPropagation/LibraryData/TBC"
+  LibraryFile: "PhotonPropagation/LibraryData/lib_protodunehd_v6_refactored_Ar_v09_76_00d00_5e5_94x87x78_ExternalVolume_20240416.root"
+
+  # Voxelisation is the result of automatic optimisation, can re-run with option below
+  #UseAutomaticVoxels: true
+
+  NX: 94
+  NY: 87
+  NZ: 78
 
   XMin: -391.564606
   XMax: 464.195190


### PR DESCRIPTION
Configuration to use the new photon library file in stashcache, with the corresponding voxelisation settings.

Generated using the automatic voxelisation option added in https://github.com/LArSoft/larsim/pull/135