### PR TITLE
Minor fix to OpHitFinderDeco_module.

### DIFF
--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.cxx
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.cxx
@@ -1,13 +1,13 @@
 // ========================================================================================
 // OpHitAlg_deco.cxx
-// This module is based on the larana/OpHitAlg.cxx. It has been updated to deal with   
-// deconvolved signals. These are the algorithms used by OpHitFinderDeco to produce optical 
+// This module is based on the larana/OpHitAlg.cxx. It has been updated to deal with
+// deconvolved signals. These are the algorithms used by OpHitFinderDeco to produce optical
 // hits. recob::OpWaveform object has been included inside the RunHitFinder_deco function.
-// Added the scaling factor inside the new RunHitFinder_deco function. It scales the values 
+// Added the scaling factor inside the new RunHitFinder_deco function. It scales the values
 // of the deconvolved signals before the hit finder.
-// 
+//
 // @authors     : Daniele Guffanti, Maritza Delgado, Sergio Manthey Corchado
-// @created     : Oct, 2022 
+// @created     : Oct, 2022
 //=========================================================================================
 
 #include "OpHitAlg_deco.h"
@@ -26,7 +26,7 @@
 
 namespace opdet {
 
- 
+
   void RunHitFinder(std::vector<raw::OpDetWaveform> const& opDetWaveformVector,
                     std::vector<recob::OpHit>& hitVector,
                     pmtana::PulseRecoManager const& pulseRecoMgr,
@@ -69,7 +69,6 @@ namespace opdet {
 
   //----------------------------------------------------------------------------
   void RunHitFinder_deco(std::vector<recob::OpWaveform>const& opWaveformVector,
-                    std::vector<raw::OpDetWaveform> const& opDetWaveformVector,
                     std::vector<recob::OpHit>& hitVector,
                     pmtana::PulseRecoManager const& pulseRecoMgr,
                     pmtana::PMTPulseRecoBase const& threshAlg,
@@ -80,29 +79,27 @@ namespace opdet {
                     calib::IPhotonCalibrator const& calibrator,
                     bool use_start_time)
   {
-      
+
      for (int i=0; i< int (opWaveformVector.size()); i++){
         recob::OpWaveform deco_waveform=opWaveformVector.at(i);
         int channel = static_cast<int>(deco_waveform.Channel());
-        //The raw timestamp is used
-        raw::OpDetWaveform waveform=opDetWaveformVector.at(i);
-        const double timeStamp = waveform.TimeStamp();
-       
+        const double timeStamp = deco_waveform.TimeStamp();
+
         if (!geometry.IsValidOpChannel(channel)) {
           mf::LogError("OpHitFinder")
           << "Error! unrecognized channel number " << channel << ". Ignoring pulse";
          continue;
         }
-      
+
        // Loop to convert from float to short
        std::vector<short int> short_deco_waveform; //vector used to convert from float to short.
        for (unsigned int i_tick=0; i_tick < deco_waveform.Signal().size(); ++i_tick)
        {
        short_deco_waveform.emplace_back(static_cast<short int>(scale*deco_waveform.Signal().at(i_tick)));
        }
-         
+
        pulseRecoMgr.Reconstruct(short_deco_waveform);
-      
+
       // Get the result
       auto const& pulses = threshAlg.GetPulses();
       for (auto const& pulse : pulses)
@@ -116,7 +113,7 @@ namespace opdet {
                      use_start_time);
      }
  }
-  
+
   //----------------------------------------------------------------------------
   void ConstructHit(float hitThreshold,
                     int channel,
@@ -137,10 +134,10 @@ namespace opdet {
      int frame = clocksData.OpticalClock().Frame(timeStamp);
      double PE = 0.0;
 
-     if (calibrator.UseArea())   
+     if (calibrator.UseArea())
        PE = calibrator.PE(pulse.area, channel);
-     else    
-      PE = calibrator.PE(pulse.peak, channel);   
+     else
+      PE = calibrator.PE(pulse.peak, channel);
 
      double width = (pulse.t_end - pulse.t_start) * clocksData.OpticalClock().TickPeriod();
 
@@ -156,6 +153,6 @@ namespace opdet {
                            PE,
                            0.0);
   }
-  
+
 
 } // End namespace opdet

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.h
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.h
@@ -1,13 +1,13 @@
 // ========================================================================================
 // OpHitAlg_deco.h
-// This module is based on the larana/OpHitAlg.h. It has been updated to deal with   
-// deconvolved signals. These are the algorithms used by OpHitFinderDeco to produce optical 
+// This module is based on the larana/OpHitAlg.h. It has been updated to deal with
+// deconvolved signals. These are the algorithms used by OpHitFinderDeco to produce optical
 // hits. recob::OpWaveform object has been included inside the RunHitFinder_deco function.
-// Added the scaling factor inside the new RunHitFinder_deco function. It scales the values 
+// Added the scaling factor inside the new RunHitFinder_deco function. It scales the values
 // of the deconvolved signals before the hit finder.
-// 
+//
 // @authors     : Daniele Guffanti, Maritza Delgado, Sergio Manthey Corchado
-// @created     : Oct, 2022 
+// @created     : Oct, 2022
 //=========================================================================================
 
 #ifndef OPHITALG_DECO_H
@@ -34,7 +34,7 @@ namespace pmtana {
 }
 
 namespace opdet {
-  
+
   void RunHitFinder(std::vector<raw::OpDetWaveform> const&,
                     std::vector<recob::OpHit>&,
                     pmtana::PulseRecoManager const&,
@@ -46,7 +46,6 @@ namespace opdet {
                     bool use_start_time = false);
 
   void RunHitFinder_deco(std::vector<recob::OpWaveform> const&,
-                    std::vector<raw::OpDetWaveform> const&,                 
                     std::vector<recob::OpHit>&,
                     pmtana::PulseRecoManager const&,
                     pmtana::PMTPulseRecoBase const&,
@@ -57,7 +56,7 @@ namespace opdet {
                     calib::IPhotonCalibrator const&,
                     bool use_start_time = false);
 
-  void ConstructHit(float,                                   
+  void ConstructHit(float,
                     int,
                     double,
                     pmtana::pulse_param const&,

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco_module.cc
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco_module.cc
@@ -2,18 +2,18 @@
 // OpHitFinderDeco_module.cc
 // This module is based on the larana/OpHitFinder module. It has been updated
 // to deal with deconvolved waveforms.The module takes either raw::OpDetWaveforms
-// (raw signals) or recob:OpWaveforms (deconvolved signals) as input,  
+// (raw signals) or recob:OpWaveforms (deconvolved signals) as input,
 // and generates OpHits as output.
 // The HitFinder algorithm can be chosen by the user.
-// Added the scaling factor inside the new RunHitFinder_deco function.  
+// Added the scaling factor inside the new RunHitFinder_deco function.
 // It scales the values of the deconvolved signals before the hit finder.
 //
 // @authors     : Daniele Guffanti, Maritza Delgado, Sergio Manthey Corchado
-// @created     : Oct, 2022 
+// @created     : Oct, 2022
 //================================================================================
- 
+
  // LArSoft includes
-#include "larcore/CoreUtils/ServiceUtil.h" 
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcore/Geometry/Geometry.h"
 #include "larana/OpticalDetector/OpHitFinder/AlgoCFD.h"
 #include "larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.h"
@@ -76,7 +76,7 @@ namespace opdet {
 
       // The parameters we'll read from the .fcl file.
       std::string fInputModule; // Input tag for OpDetWaveform collection
-      std::string fInputModuledigi; 
+      std::string fInputModuledigi;
       std::string fGenModule;
       std::string fInputDigiType;
       std::vector<std::string> fInputLabels;
@@ -119,7 +119,7 @@ namespace opdet {
 
     auto const& geometry(*lar::providerFrom<geo::Geometry>());
     fMaxOpChannel = geometry.MaxOpChannel();
-    
+
     // If useCalibrator, get it from ART
     if (useCalibrator) {fCalib = lar::providerFrom<calib::IPhotonCalibratorService>();}
     // If not useCalibrator, make an internal one based on fhicl settings to hit finder.
@@ -202,16 +202,11 @@ namespace opdet {
       std::cout << "\nRunning Ophitfinder with InputDigiType = 'recob'\n";
       // Load pulses into WaveformVector
       art::Handle<std::vector<recob::OpWaveform>> decoHandle;
-      art::Handle<std::vector<raw::OpDetWaveform>> rawHandle;
-      
+
       evt.getByLabel(fInputModule,   decoHandle);
-      evt.getByLabel(fInputModuledigi,rawHandle);
-      
       assert(decoHandle.isValid());
-      assert(rawHandle.isValid());
-   
+
       RunHitFinder_deco(*decoHandle,
-                        *rawHandle,
                         *HitPtr,
                         fPulseRecoMgr,
                         *fThreshAlg,
@@ -221,7 +216,7 @@ namespace opdet {
                         clock_data,
                         calibrator,
                         fUseStartTime);
-      }
+    }
 
     if (fInputDigiType == "raw"){
       std::cout << "\nRunning Ophitfinder with InputDigiType = 'raw'\n";
@@ -229,7 +224,7 @@ namespace opdet {
       art::Handle<std::vector<raw::OpDetWaveform>> rawHandle;
       evt.getByLabel(fInputModuledigi,rawHandle);
       assert(rawHandle.isValid());
-      
+
       if (fChannelMasks.empty() && fInputLabels.size() < 2){
         art::Handle<std::vector<raw::OpDetWaveform>> rawHandle;
         if (fInputLabels.empty()) {evt.getByLabel(fInputModuledigi, rawHandle);}
@@ -243,7 +238,7 @@ namespace opdet {
                     fHitThreshold,
                     clock_data,
                     calibrator,
-                    fUseStartTime); 
+                    fUseStartTime);
       }
 
       else{
@@ -282,5 +277,5 @@ namespace opdet {
     // Store results into the event
     std:: cout << "Found hits: " << HitPtr->size() << "!\n";
     evt.put(std::move(HitPtr));
-  }   
+  }
 } // namespace opdet


### PR DESCRIPTION
OpHitAlg_deco was trying to use raw::OpDetWaveform timestamp when processing recob::OpWaveform. This is unnecessary as the latter carries the former's timestamp, too. The way the timestamp was retrieved did not give freedom to not have recob::OpWaveforms for some raw::OpDetWaveforms.