### PR TITLE
Updates to semi-analytical model configuration

### DIFF
--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -52,7 +52,7 @@ dunefd_pdfastsim_par_xe_refl.VISHits:          @local::dune_vis_xenon_hits_param
 dunefd_pdfastsim_pvs:                          @local::standard_pdfastsim_pvs
 
 # Choose *the* pdfast sim module for the FD
-dunefd_pdfastsim:                              @local::dunefd_pdfastsim_par_ar_refl
+dunefd_pdfastsim:                              @local::dunefd_pdfastsim_par_ar
 
 
 ###########

--- a/duneopdet/PhotonPropagation/opticalsimparameterisations_dune.fcl
+++ b/duneopdet/PhotonPropagation/opticalsimparameterisations_dune.fcl
@@ -294,6 +294,8 @@ dune_vuv_RS100cm_hits_parameterization:
  
  DomePDCorr: false
 
+ MaxPDDistance: 1000 
+
  delta_angulo_vuv: 10
 }
 
@@ -316,6 +318,8 @@ dune_vuv_Xenon_hits_parameterization:
  GH_border_flat: @local::GH_border_Xenon_flat_dune
  
  DomePDCorr: false
+
+ MaxPDDistance: 2500
 
  delta_angulo_vuv: 10
 }
@@ -430,6 +434,8 @@ dune_vis_RS100cm_hits_parameterization:
  VIS_correction_flat:  @local::VIS_correction_flat_dune_argon
 
  DomePDCorr: false
+
+ MaxPDDistance: 2500
  
  delta_angulo_vis: 10
 }
@@ -540,6 +546,8 @@ dune_vis_xenon_hits_parameterization:
 
  DomePDCorr: false
  
+ MaxPDDistance: 2500
+
  delta_angulo_vis: 10
 }
 
@@ -598,6 +606,8 @@ dunevd_vuv_Argon_hits_parameterization:
 
  DomePDCorr: false
 
+ MaxPDDistance: 1000
+
  delta_angulo_vuv: 10
 
 }
@@ -655,6 +665,8 @@ dunevd_vuv_Xenon_hits_parameterization:
  GH_PARS_flat_lateral: @local::GH_PARS_Xenon_flat_lateral_dunevd
  GH_border_angulo_flat_lateral: @local::GH_border_Xenon_angulo_flat_lateral_dunevd
  GH_border_flat_lateral: @local::GH_border_Xenon_flat_lateral_dunevd
+
+ MaxPDDistance: 2500
 
  DomePDCorr: false 
 


### PR DESCRIPTION
Minor updates to semi-analytical light simulation model configuration:

1. Disables reflected light (foils) simulation for HD. This is a legacy of earlier studies looking at these foils as an extension to the PDS, but is obsolete now and adds unnecessary CPU time.
2. Adds new fhicl parameter defining maximum distance between light emission and photon detector to evaluate semi-analytical model. CPU usage optimisation to avoid unnecessary calculations for very large distances in 10kt simulation. Will be enabled through a larsim PR (with other updates for 10kt simulation) , but this PR can be merged beforehand.