### PR TITLE
SPE and noise deconvolution templates by channel

### DIFF
--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
@@ -32,11 +32,14 @@ generic_dune_deconvolution:
   Samples:           1000     # Timewindow (ReadoutWindow) in [ticks]
   Scale:             1        # Scaling of resulting deconvolution signal.
   SPETemplateFileDataColumn: 0  # SPE template source file column.
+
+  SPETemplatePath: ""
   SPETemplateFiles:          [] # The SPE template with undershoot and without pretrigger (in ADC*us),
   SPETemplateMapChannels:    []
   SPETemplateMapTemplates:   []
   IgnoreChannels:       []
 
+  NoiseTemplatePath: ""
   NoiseTemplateFiles:        []
   NoiseTemplateMapChannels:  []
   NoiseTemplateMapTemplates: []
@@ -92,16 +95,18 @@ protodunehd_deconvolution.ApplyPostfilter: true
 protodunehd_deconvolution.WfmPostfilter.Cutoff: 1.5
 protodunehd_deconvolution.ApplyPostBLCorrection: true
 
-protodunehd_deconvolution.IgnoreChannels:      @local::protodunehd_pds_channels.IgnoreChannels
+protodunehd_deconvolution.IgnoreChannels:      @local::protodunehd_pds_channels_data.IgnoreChannels
 
 # SPE Template
-protodunehd_deconvolution.SPETemplateFiles:        @local::protodunehd_pds_channels.SPETemplateFiles
-protodunehd_deconvolution.SPETemplateMapChannels:  @local::protodunehd_pds_channels.SPETemplateMapChannels
-protodunehd_deconvolution.SPETemplateMapTemplates: @local::protodunehd_pds_channels.SPETemplateMapTemplates
+protodunehd_deconvolution.SPETemplatePath:        @local::protodunehd_pds_channels_data.SPETemplatePath
+protodunehd_deconvolution.SPETemplateFiles:        @local::protodunehd_pds_channels_data.SPETemplateFiles
+protodunehd_deconvolution.SPETemplateMapChannels:  @local::protodunehd_pds_channels_data.SPETemplateMapChannels
+protodunehd_deconvolution.SPETemplateMapTemplates: @local::protodunehd_pds_channels_data.SPETemplateMapTemplates
 # Noise template
-protodunehd_deconvolution.NoiseTemplateFiles:        @local::protodunehd_pds_channels.NoiseTemplateFiles
-protodunehd_deconvolution.NoiseTemplateMapChannels:  @local::protodunehd_pds_channels.NoiseTemplateMapChannels
-protodunehd_deconvolution.NoiseTemplateMapTemplates: @local::protodunehd_pds_channels.NoiseTemplateMapTemplates
+protodunehd_deconvolution.NoiseTemplatePath:        @local::protodunehd_pds_channels_data.NoiseTemplatePath
+protodunehd_deconvolution.NoiseTemplateFiles:        @local::protodunehd_pds_channels_data.NoiseTemplateFiles
+protodunehd_deconvolution.NoiseTemplateMapChannels:  @local::protodunehd_pds_channels_data.NoiseTemplateMapChannels
+protodunehd_deconvolution.NoiseTemplateMapTemplates: @local::protodunehd_pds_channels_data.NoiseTemplateMapTemplates
 
 
 ### ProtoDUNE HD MC ###

--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
@@ -125,8 +125,8 @@ protodunehd_mc_deconvolution.SPETemplateFiles:        @local::protodunehd_pds_ch
 protodunehd_mc_deconvolution.SPETemplateMapChannels:  @local::protodunehd_pds_channels_mc.SPETemplateMapChannels
 protodunehd_mc_deconvolution.SPETemplateMapTemplates: @local::protodunehd_pds_channels_mc.SPETemplateMapTemplates
 # no noise templates used in PDHD MC
-protodunehd_deconvolution.NoiseTemplateFiles:        []
-protodunehd_deconvolution.NoiseTemplateMapChannels:  []
-protodunehd_deconvolution.NoiseTemplateMapTemplates: []
+protodunehd_mc_deconvolution.NoiseTemplateFiles:        []
+protodunehd_mc_deconvolution.NoiseTemplateMapChannels:  []
+protodunehd_mc_deconvolution.NoiseTemplateMapTemplates: []
 
 END_PROLOG

--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution_module.cc
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution_module.cc
@@ -368,12 +368,12 @@ namespace opdet {
       fSPETemplatePath{ pars().SPETemplatePath()},
       fUseSingleSPETemplate(0),
       fNoiseTemplatePath{ pars().NoiseTemplatePath()},
-      fNoiseDefault(fSamples, fLineNoiseRMS*fLineNoiseRMS*fSamples),
+      fNoiseDefault(fSamples/2+1, fLineNoiseRMS*fLineNoiseRMS*fSamples),
       fOutputProduct{ pars().OutputProduct() },
       fPostfilterConfig{ WfmExtraFilter_t( pars().Postfilter()) },
       fFilterConfig{ WfmFilter_t( pars().Filter() ) },
-      fxG0(fSamples),
-      fxG1(fSamples)
+      fxG0(fSamples/2+1),
+      fxG1(fSamples/2+1)
   {
     auto mfi = mf::LogInfo("Deconvolution::Deconvolution()");
 
@@ -545,12 +545,12 @@ namespace opdet {
       auto &xH = fSinglePEWaveforms_fft[fChannelToTemplateMap[effChannel]]; // get the SPE template relevant for this channel
       auto &speapmlitude = fSinglePEAmplitudes[fChannelToTemplateMap[effChannel]];
 
-      CmplxWaveform_t xV(fSamples);
-      CmplxWaveform_t xS(fSamples);
-      CmplxWaveform_t xG(fSamples);
-      CmplxWaveform_t xY(fSamples);
-      CmplxWaveform_t xGH(fSamples);
-      std::vector<float> xSNR(fSamples, 0.);
+      CmplxWaveform_t xV(fSamples/2+1);
+      CmplxWaveform_t xS(fSamples/2+1);
+      CmplxWaveform_t xG(fSamples/2+1);
+      CmplxWaveform_t xY(fSamples/2+1);
+      CmplxWaveform_t xGH(fSamples/2+1);
+      std::vector<float> xSNR(fSamples/2+1, 0.);
       int OriginalWaveformSize = wf.Waveform().size();
 
       // noise
@@ -611,7 +611,7 @@ namespace opdet {
       Double_t fFrequencyCutOff = fFilterConfig.fCutoff;
       Double_t fTickCutOff = fSamples*fFrequencyCutOff/fSampleFreq;
 
-      for (int i=0; i<fSamples*0.5+1; i++) {
+      for (int i=0; i<(fSamples/2+1); i++) {
 
         if (fFilterConfig.fType == Deconvolution::kWiener){
 	  // Compute spectral density
@@ -671,7 +671,7 @@ namespace opdet {
       }
 
       if (fApplyPostfilter) {
-        CmplxWaveform_t xxY(fSamples);
+        CmplxWaveform_t xxY(fSamples/2+1);
         std::vector<double> ytmp(xvdec.begin(), xvdec.end());
         fft_r2c->SetPoints(&ytmp[0]);
         fft_r2c->Transform();
@@ -784,14 +784,14 @@ namespace opdet {
       xf.at(i) = TMath::Gaus(i, mu, sigma, kTRUE);
     }
 
-    std::vector<Double_t> re_(fSamples, 0.);
-    std::vector<Double_t> im_(fSamples, 0.);
+    std::vector<Double_t> re_(fSamples/2+1, 0.);
+    std::vector<Double_t> im_(fSamples/2+1, 0.);
 
     fft_r2c->SetPoints(&xf[0]);
     fft_r2c->Transform();
     fft_r2c->GetPointsComplex(&re_[0], &im_[0]);
 
-    for (int i=0; i<0.5*fSamples+1; i++) {
+    for (int i=0; i<fSamples/2+1; i++) {
       TComplex F(re_.at(i), im_.at(i));
       TComplex phase = TComplex(0., -TMath::TwoPi()*i*mu/(fSamples));
       xF.fCmplx.at(i) = F*TComplex::Exp(phase);
@@ -940,7 +940,7 @@ namespace opdet {
 	throw art::Exception(art::errors::FileOpenError);
       }
 
-      noisewfrm.resize(fSamples, 0.);
+      noisewfrm.resize(fSamples/2+1, 0.); // for power spectrum, need only half of the sample size
 
       noiseData.close();
 
@@ -1017,7 +1017,7 @@ namespace opdet {
     // Apply a linear phase shift to make the "pulse" in the middle of the
     // time window
     const int shift = 0.5*fSamples;
-    for (int i=0; i<fSamples*0.5+1; i++) {
+    for (int i=0; i<fSamples/2+1; i++) {
      TComplex phase = TComplex(0., TMath::TwoPi()*i*shift/(fSamples));
      xGH.fCmplx.at(i) = xGH.fCmplx.at(i)*TComplex::Exp(phase);
     }

--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution_module.cc
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution_module.cc
@@ -93,9 +93,12 @@ namespace opdet {
           fhicl::Atom<Double_t>    LineNoiseRMS{ fhicl::Name("LineNoiseRMS"), 1.0 };
           fhicl::Atom<size_t>      PreTrigger{ fhicl::Name("PreTrigger"), 0};
           fhicl::Atom<short>       Pedestal{ fhicl::Name("Pedestal"), 1500};
-          fhicl::Sequence<std::string> SPETemplateFiles{ fhicl::Name("SPETemplateFiles") };
-          fhicl::Atom<size_t>      SPETemplateFileDataColumn{ fhicl::Name("SPETemplateFileDataColumn"), 1 };
-          fhicl::Sequence<std::string> NoiseTemplateFiles{ fhicl::Name("NoiseTemplateFiles") };
+
+	  fhicl::Atom<std::string>      SPETemplatePath{ fhicl::Name("SPETemplatePath"), "" };
+          fhicl::Atom<std::string>      NoiseTemplatePath{ fhicl::Name("NoiseTemplatePath"), "" };
+	  fhicl::Sequence<std::string>  SPETemplateFiles{ fhicl::Name("SPETemplateFiles") };
+          fhicl::Atom<size_t>           SPETemplateFileDataColumn{ fhicl::Name("SPETemplateFileDataColumn"), 1 };
+          fhicl::Sequence<std::string>  NoiseTemplateFiles{ fhicl::Name("NoiseTemplateFiles") };
 
           fhicl::Atom<Int_t>       Samples{ fhicl::Name("Samples"), 1000 };
           fhicl::Atom<Int_t>       PedestalBuffer{ fhicl::Name("PedestalBuffer"), 10 };
@@ -104,17 +107,17 @@ namespace opdet {
           fhicl::Atom<bool>        ApplyPostBLCorrection{ fhicl::Name("ApplyPostBLCorrection") };
           fhicl::Atom<bool>        AutoScale{ fhicl::Name("AutoScale"), false };
 
-	fhicl::Atom<short>        InputPolarity{ fhicl::Name("InputPolarity") };
+	  fhicl::Atom<short>        InputPolarity{ fhicl::Name("InputPolarity") };
 
 
-	fhicl::Atom<std::string> OutputProduct{ fhicl::Name("OutputProduct"), "decowave"};
+	  fhicl::Atom<std::string> OutputProduct{ fhicl::Name("OutputProduct"), "decowave"};
 
           fhicl::Sequence<int>          SPETemplateMap_channels{ fhicl::Name("SPETemplateMapChannels") };
           fhicl::Sequence<unsigned int> SPETemplateMap_templates{ fhicl::Name("SPETemplateMapTemplates") };
           fhicl::Sequence<unsigned int> NoiseTemplateMap_channels{ fhicl::Name("NoiseTemplateMapChannels") };
           fhicl::Sequence<unsigned int> NoiseTemplateMap_templates{ fhicl::Name("NoiseTemplateMapTemplates") };
 
-	fhicl::Sequence<int> IgnoreChannels{ fhicl::Name("IgnoreChannels") }; // integer to allow for channel -1 = unrecognized channel
+	  fhicl::Sequence<int> IgnoreChannels{ fhicl::Name("IgnoreChannels") }; // integer to allow for channel -1 = unrecognized channel
 
 
           struct Filter {
@@ -295,11 +298,13 @@ namespace opdet {
       std::vector<CmplxWaveform_t> fSinglePEWaveforms_fft;    //!< Fourier transform of the tamplates
       std::vector<double> fSinglePEAmplitudes;                //!< single PE amplitude for found maximum peak in the template.
       unsigned int WfDeco;                      //!< Number of waveform processed
+      std::string fSPETemplatePath;
       std::map<unsigned int, unsigned int> fChannelToTemplateMap; //!< maps a channel id to the input SPE  template file (index in fSinglePEWaveforms)
       unsigned short fUseSingleSPETemplate;
       std::set<int> fIgnoreChannels; //!< List of channels to ignore in deconvolution
 
       // Noise templates -- input in frequency domain
+      std::string fNoiseTemplatePath;
       std::vector<std::vector<double> > fNoiseTemplates;    //!< Vector that stores noise template in frequency domain
       std::map<unsigned int, unsigned int> fChannelToNoiseTemplateMap; //!< maps a channel id to the input SPE  template file (index in fSingle
       std::vector<double> fNoiseDefault;
@@ -360,7 +365,9 @@ namespace opdet {
       fApplyPostBLCorr{ pars().ApplyPostBLCorrection()},
       fAutoScale{ pars().AutoScale()},
       fInputPolarity{ pars().InputPolarity()},
+      fSPETemplatePath{ pars().SPETemplatePath()},
       fUseSingleSPETemplate(0),
+      fNoiseTemplatePath{ pars().NoiseTemplatePath()},
       fNoiseDefault(fSamples, fLineNoiseRMS*fLineNoiseRMS*fSamples),
       fOutputProduct{ pars().OutputProduct() },
       fPostfilterConfig{ WfmExtraFilter_t( pars().Postfilter()) },
@@ -852,6 +859,8 @@ namespace opdet {
       fSinglePEWaveforms.push_back(std::vector<double>()); // add a new empty waform
       auto &spewfrm = fSinglePEWaveforms.back(); // get the reference to the waveform vector
       std::string datafile;
+      // Update the file name to search with a configured path prefix
+      fname = fSPETemplatePath + fname;
       // taking the file name as the first argument,
       // the second argument is the local variable where to store the full path - both are std::string objects
       sp.find_file(fname, datafile);
@@ -908,6 +917,8 @@ namespace opdet {
       fNoiseTemplates.push_back(std::vector<double>()); // add a new empty waform
       auto &noisewfrm = fNoiseTemplates.back(); // get the reference to the waveform vector
       std::string datafile;
+      // Update the file name to search with a configured path prefix
+      fname = fNoiseTemplatePath + fname;
       // taking the file name as the first argument,
       // the second argument is the local variable where to store the full path - both are std::string objects
       sp.find_file(fname, datafile);

--- a/duneopdet/OpticalDetector/Deconvolution/dune_opdet_channels.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/dune_opdet_channels.fcl
@@ -1,8 +1,9 @@
+#include "protodunehd_first_template_list.fcl"
 BEGIN_PROLOG
 
 ### ProtoDUNE HD ###
 
-protodunehd_pds_channels: {
+protodunehd_pds_channels_data_dummy: {
    FBKChannels:          [4,14,24,34,40,42,45,46,47,49,50,52,55,56,57,59,60,62, 65,66,67,69,70,72,75,76,77,79,84,85,86,87,94,95,96,97,104,105,106,107,114,115,116,117,120,121,124,125,127,129,130,131,134,135,137,139,140,141,144,145,147,149,150,151,154,155,157,159] # 68 channels
 
    HPKChannels:         [0, 1,2,3,5,6,7,8,9,10,11,12,13,15,16,17,18,19,20,21,22,23,25,26,27,28,29,30,31,32,33,35,36,37,38,39,41,43,44,48,51,53,54,58,61,63,64,68,71,73,74,78,80,81,82,83,88,89,90,91,92,93,98,99,100,101,102,103,108,109,110,111,112,113,118,119,122,123,126,128,132,133,136,138,142,143,146,148,152,153,156,158] # 92 channels
@@ -30,24 +31,36 @@ protodunehd_pds_channels: {
    NoiseTemplateMapTemplates: [ 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 ]
 
 }
-
-
-protodunehd_pds_channels.SPETemplateMapChannels: [
-   @sequence::protodunehd_pds_channels.FBKChannels,
-   @sequence::protodunehd_pds_channels.HPKChannels
-]
-protodunehd_pds_channels.SPETemplateMapTemplates: [
-   @sequence::protodunehd_pds_channels.SPETemplateMapChannelToFile_FBK,
-   @sequence::protodunehd_pds_channels.SPETemplateMapChannelToFile_HPK
-]
-
-
-protodunehd_pds_channels.IgnoreChannels: [
+protodunehd_pds_channels_data_dummy.IgnoreChannels: [
    -1, # ignore disconnected/unrecognized channels
-   @sequence::protodunehd_pds_channels.Dead_channels,
-   @sequence::protodunehd_pds_channels.Noise_channels,
-   @sequence::protodunehd_pds_channels.APA1_full_stream_channels
+   @sequence::protodunehd_pds_channels_data_dummy.Dead_channels,
+   @sequence::protodunehd_pds_channels_data_dummy.Noise_channels,
+   @sequence::protodunehd_pds_channels_data_dummy.APA1_full_stream_channels
 ]
+protodunehd_pds_channels_data_dummy.SPETemplateMapChannels: [
+   @sequence::protodunehd_pds_channels_data_dummy.FBKChannels,
+   @sequence::protodunehd_pds_channels_data_dummy.HPKChannels
+]
+protodunehd_pds_channels_data_dummy.SPETemplateMapTemplates: [
+   @sequence::protodunehd_pds_channels_data_dummy.SPETemplateMapChannelToFile_FBK,
+   @sequence::protodunehd_pds_channels_data_dummy.SPETemplateMapChannelToFile_HPK
+]
+
+
+# ProtoDUNE HD data
+protodunehd_pds_channels_data: {
+   SPETemplatePath:		@local::protodunehd_first_template_list.spe_template_path
+   SPETemplateFiles:		@local::protodunehd_first_template_list.spe_template_files
+   SPETemplateMapChannels:	@local::protodunehd_first_template_list.spe_template_channels
+   SPETemplateMapTemplates:	@local::protodunehd_first_template_list.spe_template_id
+
+   NoiseTemplatePath:		@local::protodunehd_first_template_list.noise_template_path
+   NoiseTemplateFiles:		@local::protodunehd_first_template_list.noise_template_files
+   NoiseTemplateMapChannels:	@local::protodunehd_first_template_list.noise_template_channels
+   NoiseTemplateMapTemplates:	@local::protodunehd_first_template_list.noise_template_id
+
+   IgnoreChannels:		@local::protodunehd_first_template_list.ignore_channels
+}
 
 
 ### ProtoDUNE HD MC ###

--- a/duneopdet/OpticalDetector/Deconvolution/protodunehd_deconvolution_run.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/protodunehd_deconvolution_run.fcl
@@ -1,6 +1,6 @@
 #include "deconvolution_run.fcl"
 
-process_name: TestDeconv
+process_name: RecoDeconv
 
 services:
 {
@@ -11,35 +11,34 @@ services:
    @table::protodunehd_services
 }
 
-source.inputCommands: [ "keep *", "drop *_*_*_opdec" ]
-outputs.out1.outputCommands: [ "keep *_*_*_TestDeconv", "keep *_pdhddaphne_*_*" ]
-
-
 physics.simulate: @erase
 physics.reco: [ opdec, rns ]
 physics.trigger_paths: [ reco ]
 
 
-physics.producers.opdec: @local::protodunehd_deconvolution
+physics.producers.opdec: {
+   @table::protodunehd_deconvolution
+
+   Pedestal: 8180
+   PreTrigger: 50
+   PedestalBuffer: 30
+   InputModule: "pdhddaphne"
+   InstanceName: "daq"
+
+   # PD HD raw waveforms have negative polarity
+   InputPolarity: -1
 
 
-physics.producers.opdec.Pedestal: 8180
-physics.producers.opdec.PreTrigger: 50
-physics.producers.opdec.PedestalBuffer: 30
-physics.producers.opdec.InputModule: "pdhddaphne"
-physics.producers.opdec.InstanceName: "daq"
-
-# PD HD raw waveforms have negative polarity
-physics.producers.opdec.InputPolarity: -1
+   LineNoiseRMS: 4.5
 
 
-physics.producers.opdec.LineNoiseRMS: 4.5
-
-
-physics.producers.opdec.ApplyPostfilter: true
-physics.producers.opdec.WfmPostfilter.Cutoff: 1.5
-physics.producers.opdec.ApplyPostBLCorrection: true
-
+   ApplyPostfilter: true
+   WfmPostfilter: {
+      @table::protodunehd_deconvolution.WfmPostfilter
+      Cutoff: 1.5
+   }
+   ApplyPostBLCorrection: true
+}
 
 physics.analyzers.opdecoana.InputModuleDeco: "opdec"
 physics.analyzers.opdecoana.InputModuleDigi: "pdhddaphne"

--- a/duneopdet/OpticalDetector/Deconvolution/protodunehd_deconvolution_run.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/protodunehd_deconvolution_run.fcl
@@ -14,6 +14,12 @@ services:
 source.inputCommands: [ "keep *", "drop *_*_*_opdec" ]
 outputs.out1.outputCommands: [ "keep *_*_*_TestDeconv", "keep *_pdhddaphne_*_*" ]
 
+
+physics.simulate: @erase
+physics.reco: [ opdec, rns ]
+physics.trigger_paths: [ reco ]
+
+
 physics.producers.opdec: @local::protodunehd_deconvolution
 
 

--- a/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
@@ -135,8 +135,8 @@ protodunehd_first_template_list: {
 
    noise_template_path: "ProtoDUNE/HD/opdetresponse/"
    noise_template_files: [
-      "FFT_Noise_Template_run27950_PDHD_VGain2318_fbk_Nov2024.txt",
-      "FFT_Noise_Template_run27950_PDHD_VGain2318_hpk_Nov2024.txt"
+      "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_fbk_Nov2024.txt",
+      "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_hpk_Nov2024.txt"
    ]
 
    noise_template_channels: [

--- a/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
@@ -135,8 +135,8 @@ protodunehd_first_template_list: {
 
    noise_template_path: "ProtoDUNE/HD/opdetresponse/"
    noise_template_files: [
-      "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_fbk_Nov2024.txt",
-      "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_hpk_Nov2024.txt"
+      "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_fbk_Dec2024.txt",
+      "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_hpk_Dec2024.txt"
    ]
 
    noise_template_channels: [

--- a/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
@@ -1,7 +1,7 @@
 BEGIN_PROLOG
 
 protodunehd_first_template_list: {
-   spe_template_path: "ProtoDUNE/HD/opdetresponse/"
+   spe_template_path: "ProtoDUNE/HD/opdetresponse/v0/"
    spe_template_files: [
       "SPE_Template_run28370_APA4_CH0_PDHD_hpk_Nov2024.txt",
       "SPE_Template_run28370_APA4_CH1_PDHD_hpk_Nov2024.txt",
@@ -133,7 +133,7 @@ protodunehd_first_template_list: {
       100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111
    ]
 
-   noise_template_path: "ProtoDUNE/HD/opdetresponse/"
+   noise_template_path: "ProtoDUNE/HD/opdetresponse/v0/"
    noise_template_files: [
       "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_fbk_Dec2024.txt",
       "FFT_Noise_Template_run27950_PDHD_VGain2318_sample513_hpk_Dec2024.txt"

--- a/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
@@ -1,0 +1,177 @@
+BEGIN_PROLOG
+
+protodunehd_first_template_list: {
+   spe_template_path: "ProtoDUNE/HD/opdetresponse/"
+   spe_template_files: [
+      "SPE_Template_run28370_APA4_CH0_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH1_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH2_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH4_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH5_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH6_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH7_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH8_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH9_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH10_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH11_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH12_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH13_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH14_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH15_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH16_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH17_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH18_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH19_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH20_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH21_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH22_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH23_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH24_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH25_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH26_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH27_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH28_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH29_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH30_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH31_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH32_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH33_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH34_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH36_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH37_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH38_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA4_CH39_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH40_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH41_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH42_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH43_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH44_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH45_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH46_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH47_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH48_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH49_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH50_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH51_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH52_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH53_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH54_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH55_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH56_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH57_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH58_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH59_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH60_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH61_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH62_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH63_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH64_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH65_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH66_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH67_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH68_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH69_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH70_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH71_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH72_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH73_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH74_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH75_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH76_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH77_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH78_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28370_APA3_CH79_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH80_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH81_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH82_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH83_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH84_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH85_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH88_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH89_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH90_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH91_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH92_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH93_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH94_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH95_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH96_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH98_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH99_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH100_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH101_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH102_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH103_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH104_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH105_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH106_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH108_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH109_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH110_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH111_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH112_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH113_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH114_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH115_PDHD_fbk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH118_PDHD_hpk_Nov2024.txt",
+      "SPE_Template_run28492_APA2_CH119_PDHD_hpk_Nov2024.txt"
+   ]
+   spe_template_channels: [
+      0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 36, 37, 38, 39, 40,
+      41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+      61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+      81, 82, 83, 84, 85, 88, 89, 90, 91, 92, 93, 94, 95, 96, 98, 99, 100,
+      101, 102, 103, 104, 105, 106, 108, 109, 110, 111, 112, 113, 114, 115, 118, 119
+   ]
+   spe_template_id: [
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+      40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+      60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+      80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99,
+      100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111
+   ]
+
+   noise_template_path: "ProtoDUNE/HD/opdetresponse/"
+   noise_template_files: [
+      "FFT_Noise_Template_run27950_PDHD_VGain2318_fbk_Nov2024.txt",
+      "FFT_Noise_Template_run27950_PDHD_VGain2318_hpk_Nov2024.txt"
+   ]
+
+   noise_template_channels: [
+      4,14,24,34,40,42,45,46,47,49,50,52,55,56,57,59,60,62,
+      65,66,67,69,70,72,75,76,77,79,84,85,86,87,94,95,96,97,
+      104,105,106,107,114,115,116,117,120,121,124,125,127,129,
+      130,131,134,135,137,139,140,141,144,145,147,149,150,151,
+      154,155,157,159, # FBK, 68 channels
+      0,1,2,3,5,6,7,8,9,10,11,12,13,15,16,17,18,19,20,21,22,23,
+      25,26,27,28,29,30,31,32,33,35,36,37,38,39,41,43,44,48,51,
+      53,54,58,61,63,64,68,71,73,74,78,80,81,82,83,88,89,90,91,
+      92,93,98,99,100,101,102,103,108,109,110,111,112,113,118,119,
+      122,123,126,128,132,133,136,138,142,143,146,148,152,153,156,158 # HPK, 92 channels
+   ]
+
+   noise_template_id: [
+      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+      0,0,0,0,0,0,0,0, # FBK, 68 channels
+      1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+      1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+      1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+      1,1 # HPK, 92 channels
+   ]
+
+   ignore_channels: [
+      86,87,97,107,116,117,147, #dead  channels
+      3,135, # noisy channels
+      120,121,122,123,124,125,126,127,128,129,
+      130,131,132,133,134,135,136,137,138,139,
+      140,141,142,143,144,145,146,147,148,149,
+      150,151,152,153,154,155,156,157,158,159, # full-stream channels, ch 135 also noisy, ch 147 dead
+      35 # missing SPE template
+   ]
+}
+
+
+END_PROLOG


### PR DESCRIPTION
These changes add the capability of the deconvolution module to be configured with SPE and noise templates per channel. 

The template files will be searched for within FW_SEARCH_PATH.

Standard configuration for running on PDHD data is given where the template files are stored in StashCache.