### PR TITLE
Switch Signal() w/ SignalROI() to speed up op hit finder

### DIFF
--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.cxx
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.cxx
@@ -93,9 +93,9 @@ namespace opdet {
 
        // Loop to convert from float to short
        std::vector<short int> short_deco_waveform; //vector used to convert from float to short.
-       for (unsigned int i_tick=0; i_tick < deco_waveform.Signal().size(); ++i_tick)
+       for (unsigned int i_tick=0; i_tick < deco_waveform.SignalROI().size(); ++i_tick)
        {
-       short_deco_waveform.emplace_back(static_cast<short int>(scale*deco_waveform.Signal().at(i_tick)));
+       short_deco_waveform.emplace_back(static_cast<short int>(scale*deco_waveform.SignalROI()[i_tick]));
        }
 
        pulseRecoMgr.Reconstruct(short_deco_waveform);


### PR DESCRIPTION
I noticed that the OpHitFinder was taking a very long time to run on one event in MC. The fix is to replace the instances of `Signal()` wiith `SignalROI()` in `OpHitAlg_deco.cxx`, otherwise the code is looping over the whole waveforms, which includes the very long streaming waveforms. This aligns with the same change made by Jose in [an analyzer](https://github.com/DUNE/duneopdet/blob/0c6467d41b6b78fb9ec0e5c820b7ef53d57f1779/duneopdet/OpticalDetector/Deconvolution/DecoAnalysis_module.cc#L177).