### PR TITLE
Configs of comp graph modules for pdvd v4 added

### DIFF
--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -196,7 +196,7 @@ protodune_hd_pdfastsim_ann_ar:
 # protoDUNE-VD #
 ################
 
-protodune_vd_pdfastsim_ann_ar:
+protodune_vd_v2_pdfastsim_ann_ar:
 {
        # Computable graph generated for protodunevd_v2_refactored.gdml
        module_type:         "PDFastSimANN"
@@ -206,18 +206,38 @@ protodune_vd_pdfastsim_ann_ar:
        TFLoaderTool:
        {
            tool_type:       TFLoaderMLP
-           ModelName:       "PhotonPropagation/ComputableGraph/protodune_vd_128nm_tf2.6"
+           ModelName:       "PhotonPropagation/ComputableGraph/protodune_vd_v2_128nm_tf2.6"
            InputsName:      ["serving_default_pos_x:0", "serving_default_pos_y:0", "serving_default_pos_z:0"]
            OutputName:      "StatefulPartitionedCall:0"
        }
 }
 
-protodune_vd_pdfastsim_pvs: @local::protodune_hd_pdfastsim_pvs
+protodune_vd_v2_pdfastsim_pvs: @local::protodune_hd_pdfastsim_pvs
 
-protodune_vd_pdfastsim_ann_xe:                          @local::protodune_vd_pdfastsim_ann_ar
-protodune_vd_pdfastsim_ann_xe.ScintTimeTool:            @local::ScintTimeXeDoping10ppm
-protodune_vd_pdfastsim_ann_xe.TFLoaderTool.ModelName:   "PhotonPropagation/ComputableGraph/protodune_vd_175nm_tf2.6"
+protodune_vd_v2_pdfastsim_ann_xe:                          @local::protodune_vd_v2_pdfastsim_ann_ar
+protodune_vd_v2_pdfastsim_ann_xe.ScintTimeTool:            @local::ScintTimeXeDoping10ppm
+protodune_vd_v2_pdfastsim_ann_xe.TFLoaderTool.ModelName:   "PhotonPropagation/ComputableGraph/protodune_vd_v2_175nm_tf2.6"
 
+
+protodune_vd_v4_pdfastsim_ann_ar:
+{
+       #Computable graph generated for protodunevd_v4_refactored.gdml
+       module_type:         "PDFastSimANN"
+       SimulationLabel:     "IonAndScint"
+       DoSlowComponent:     true
+       ScintTimeTool:       @local::ScintTimeLAr
+       TFLoaderTool:
+       {
+           tool_type:       TFLoaderMLP
+           ModelName:       "PhotonPropagation/ComputableGraph/protodune_vd_v4_128nm_tf2.6"
+           InputsName:      ["serving_default_pos_x:0", "serving_default_pos_y:0", "serving_default_pos_z:0"]
+           OutputName:      "StatefulPartitionedCall:0"
+       }
+}
+
+protodune_vd_v4_pdfastsim_ann_xe:                          @local::protodune_vd_v4_pdfastsim_ann_ar
+protodune_vd_v4_pdfastsim_ann_xe.ScintTimeTool:            @local::ScintTimeXeDoping10ppm
+protodune_vd_v4_pdfastsim_ann_xe.TFLoaderTool.ModelName:   "PhotonPropagation/ComputableGraph/protodune_vd_v4_175nm_tf2.6"
 
 
 END_PROLOG

--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -58,6 +58,7 @@ dunefd_pdfastsim:                              @local::dunefd_pdfastsim_par_ar
 ###########
 # DUNE VD #
 ###########
+
 # Hits & Timing parameterization for DUNE VD, Ar scintillation
 dunevd_pdfastsim_par_ar:                       @local::standard_pdfastsim_par_ar
 dunevd_pdfastsim_par_ar.VUVTiming:             @local::dunevd_vuv_timing_parameterization
@@ -120,6 +121,7 @@ protodune_pdfastsim_pvs.SimulationLabel:       "IonAndScint:priorSCE"
 ################
 # ProtoDUNE-HD #
 ################
+
 # Hits & Timing parameterization for ProtoDUNE-HD
 protodune_hd_pdfastsim_par:                       @local::standard_pdfastsim_par_ar
 protodune_hd_pdfastsim_par.VUVTiming:             @local::dune_vuv_timing_parameterization
@@ -137,9 +139,24 @@ protodune_hd_pdfastsim_pvs_external.DoSlowComponent:          true
 protodune_hd_pdfastsim_pvs_external.DoReflectedLight:         false         
 protodune_hd_pdfastsim_pvs_external.VUVTiming:	  	      @local::dune_vuv_timing_parameterization
 
+
+
+#####################################
+### PHOTON LIBRARY CONFIGURATIONS ###
+#####################################
+
+################
+# ProtoDUNE-HD #
+################
+
 protodune_hd_pdfastsim_pvs: @local::protodune_hd_pdfastsim_pvs_external
 protodune_hd_pdfastsim_pvs.SimulationLabel:          IonAndScint
 
+################
+# protoDUNE-VD #
+################
+
+protodune_vd_pdfastsim_pvs: @local::protodune_hd_pdfastsim_pvs
 
 
 
@@ -198,7 +215,7 @@ protodune_hd_pdfastsim_ann_ar:
 
 protodune_vd_v2_pdfastsim_ann_ar:
 {
-       # Computable graph generated for protodunevd_v2_refactored.gdml
+       #Computable graph generated for protodunevd_v2_refactored.gdml
        module_type:         "PDFastSimANN"
        SimulationLabel:     "IonAndScint"
        DoSlowComponent:     true
@@ -212,12 +229,9 @@ protodune_vd_v2_pdfastsim_ann_ar:
        }
 }
 
-protodune_vd_v2_pdfastsim_pvs: @local::protodune_hd_pdfastsim_pvs
-
 protodune_vd_v2_pdfastsim_ann_xe:                          @local::protodune_vd_v2_pdfastsim_ann_ar
 protodune_vd_v2_pdfastsim_ann_xe.ScintTimeTool:            @local::ScintTimeXeDoping10ppm
 protodune_vd_v2_pdfastsim_ann_xe.TFLoaderTool.ModelName:   "PhotonPropagation/ComputableGraph/protodune_vd_v2_175nm_tf2.6"
-
 
 protodune_vd_v4_pdfastsim_ann_ar:
 {

--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -254,4 +254,9 @@ protodune_vd_v4_pdfastsim_ann_xe.ScintTimeTool:            @local::ScintTimeXeDo
 protodune_vd_v4_pdfastsim_ann_xe.TFLoaderTool.ModelName:   "PhotonPropagation/ComputableGraph/protodune_vd_v4_175nm_tf2.6"
 
 
+#Official PDVD ANN fast sim
+protodune_vd_pdfastsim_ann_ar:                          @local::protodune_vd_v4_pdfastsim_ann_ar
+protodune_vd_pdfastsim_ann_xe:                          @local::protodune_vd_v4_pdfastsim_ann_xe
+
+
 END_PROLOG


### PR DESCRIPTION
1. Added the configurations of computable graph modules for pdvd v4 geometry (protodune_vd_v4_pdfastsim_ann_ar & protodune_vd_v4_pdfastsim_ann_xe); The old protodune_vd_pdfastsim_ann_ar is for v2 geometry, which is relatively old. Hence, the old is renamed as protodune_vd_v2_pdfastsim_ann_ar.
2. Added a block for photon library, to make the configurations of different methods more distinguishable.
3. New module files are now at the hand of Ken. Expect they will be uploaded recently.
4. Corresponding g4 stage fhicl in dunesw is also modified. The PR for dunesw will happen soon.