### PR TITLE
Ignore disconnected channels in PDHD data deconvolution

### DIFF
--- a/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/protodunehd_first_template_list.fcl
@@ -163,6 +163,7 @@ protodunehd_first_template_list: {
    ]
 
    ignore_channels: [
+      -1, # ignore disconnected channels
       86,87,97,107,116,117,147, #dead  channels
       3,135, # noisy channels
       120,121,122,123,124,125,126,127,128,129,


### PR DESCRIPTION
Adding -1 to the list of channels to ignore for configuration of deconvolution of PDHD data. Offline channel -1 is assigned to hardware channels which are not mapped to any sensitive detector.