### PR TITLE
Fix OpHitFinder's namespace

### DIFF
--- a/duneopdet/OpticalDetector/OpHitFinder/OpFlashAnaDeco_module.cc
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpFlashAnaDeco_module.cc
@@ -39,7 +39,7 @@
 #include "canvas/Persistency/Common/Ptr.h"
 #include "fhiclcpp/ParameterSet.h"
 
-namespace opdet {
+namespace duneopdet {
 
   class OpFlashAnaDeco : public art::EDAnalyzer {
   public:
@@ -127,7 +127,7 @@ namespace opdet {
 
 #endif
 
-namespace opdet {
+namespace duneopdet {
 
   //-----------------------------------------------------------------------
   // Constructor
@@ -439,8 +439,8 @@ namespace opdet {
     }
   }
 
-} // namespace opdet
+} // namespace duneopdet
 
-namespace opdet {
+namespace duneopdet {
   DEFINE_ART_MODULE(OpFlashAnaDeco)
 }

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.cxx
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.cxx
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-namespace opdet {
+namespace duneopdet {
 
 
   void RunHitFinder(std::vector<raw::OpDetWaveform> const& opDetWaveformVector,
@@ -155,4 +155,4 @@ namespace opdet {
   }
 
 
-} // End namespace opdet
+} // End namespace duneopdet

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.h
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitAlg_deco.h
@@ -31,7 +31,7 @@ namespace pmtana {
   class PulseRecoManager;
 }
 
-namespace opdet {
+namespace duneopdet {
 
   void RunHitFinder(std::vector<raw::OpDetWaveform> const&,
                     std::vector<recob::OpHit>&,
@@ -63,6 +63,6 @@ namespace opdet {
                     calib::IPhotonCalibrator const&,
                     bool use_start_time = false);
 
-} // End opdet namespace
+} // End duneopdet namespace
 
 #endif

--- a/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco_module.cc
+++ b/duneopdet/OpticalDetector/OpHitFinder/OpHitFinderDeco_module.cc
@@ -59,7 +59,7 @@ namespace {
   }
 }
 
-namespace opdet {
+namespace duneopdet {
   class OpHitFinderDeco : public art::EDProducer {
     public:
       // Standard constructor and destructor for an ART module.
@@ -96,11 +96,11 @@ namespace opdet {
 
 }
 
-namespace opdet {
+namespace duneopdet {
   DEFINE_ART_MODULE(OpHitFinderDeco)
 }
 
-namespace opdet {
+namespace duneopdet {
   //----------------------------------------------------------------------------
   // Constructor
   OpHitFinderDeco::OpHitFinderDeco(const fhicl::ParameterSet& pset) : EDProducer{pset}, fPulseRecoMgr(){
@@ -282,4 +282,4 @@ namespace opdet {
     std:: cout << "Found hits: " << HitPtr->size() << "!\n";
     evt.put(std::move(HitPtr));
   }
-} // namespace opdet
+} // namespace duneopdet


### PR DESCRIPTION
Changing OpHiFinder's namespace to `duneopdet` in order to avoid clashes with similar code in `larana/OpticalDetector/OpHitFinder`.

Code can be silently linked to stuff in the `larana` version. I was testing changes in `OpHitAlg_deco.cxx`, namely I changed stuff in its `ConstructHit` function, but they were not showing at runtime. I found out that the `larana` version of this function was used even when called from code inside  `duneopdet`'s `OpHitAlg_deco.cxx`.