### PR TITLE
PhotonVisibilityExport module extension

### DIFF
--- a/duneopdet/PhotonPropagation/NeedsTensorflow/PhotonVisibilityExport.fcl
+++ b/duneopdet/PhotonPropagation/NeedsTensorflow/PhotonVisibilityExport.fcl
@@ -2,6 +2,20 @@
 
 BEGIN_PROLOG
 
+semianalytical_model_settings: {
+  do_refl:                  @local::dunefd_pdfastsim_par_ar_refl.DoReflectedLight
+  do_include_anode_refl:    false
+  vuvhitspars:              @local::dunefd_pdfastsim_par_ar.VUVHits
+  vishitspars:              @local::dunefd_pdfastsim_par_ar_refl.VISHits
+}
+
+computablegraph_settings: {
+  tfloaderpars: @local::dunevd_pdfastsim_ann_ar.TFLoaderTool
+}
+
+photonlibrary_settings: {}
+
+
 standard_photovisexport: 
 {
    module_type:  "PhotonVisibilityExport"
@@ -13,40 +27,29 @@ standard_photovisexport:
    n_vis_samplings:               "5"     # nr of visibility samplings inside the voxel (min 1)
 
    tpc_vis_model: {
-      model_type: "semianalytical" # visibility model to be used
-                                   # (pick one between "semianalytical", "compgraph")
-      settings: {
-        do_refl:                  @local::dunefd_pdfastsim_par_ar_refl.DoReflectedLight
-        do_include_anode_refl:    false
-        vuvhitspars:              @local::dunefd_pdfastsim_par_ar.VUVHits
-        vishitspars:              @local::dunefd_pdfastsim_par_ar_refl.VISHits
-      }
-      #   model_type:        "compgraph" #
-      #   settings : {
-      #     tfloaderpars:			       @local::dunevd_pdfastsim_ann_ar.TFLoaderTool
-      #   }
+      model_type: "" # visibility model to be used
+      settings: {}
    }      
-   do_include_buffer:        true   # include buffer region 
 
+   do_include_buffer: true   # include buffer region 
    buf_vis_model: {
-    model_type: "photonlibrary"
+    model_type: ""
     settings: {}
-    #  model_type: "compgraph"
-    #  settings: {
-    #    tfloaderpars: @local::dunevd_pdfastsim_ann_ar.TFLoaderTool
-    #  }
-
    }
 }
 
 photovisexport_fdhd: @local::standard_photovisexport
+photovisexport_fdhd.tpc_vis_model.model_type: "semianalytical"
+photovisexport_fdhd.tpc_vis_model.settings: @local::semianalytical_model_settings
+photovisexport_fdhd.buf_vis_model.model_type: "photonlibrary"
+photovisexport_fdhd.buf_vis_model.settings: {}
 
-photovisexport_fdvd_ar: @local::standard_photovisexport
+photovisexport_fdvd_ar: @local::photovisexport_fdhd
 photovisexport_fdvd_ar.tpc_vis_model.vuvhitspars: @local::dunevd_pdfastsim_par_ar.VUVHits
 photovisexport_fdvd_ar.tpc_vis_model.do_refl: @local::dunevd_pdfastsim_par_ar.DoReflectedLight
 photovisexport_fdvd_ar.tpc_vis_model.do_include_anode_refl: @local::dunevd_pdfastsim_par_ar.IncludeAnodeReflections
 
-photovisexport_fdvd_xe: @local::standard_photovisexport
+photovisexport_fdvd_xe: @local::photovisexport_fdhd
 photovisexport_fdvd_xe.tpc_vis_model.vuvhitspars: @local::dunevd_pdfastsim_par_xe.VUVHits
 photovisexport_fdvd_xe.tpc_vis_model.do_refl: @local::dunevd_pdfastsim_par_xe.DoReflectedLight
 photovisexport_fdvd_xe.tpc_vis_model.do_include_anode_refl: @local::dunevd_pdfastsim_par_xe.IncludeAnodeReflections

--- a/duneopdet/PhotonPropagation/NeedsTensorflow/PhotonVisibilityExport.fcl
+++ b/duneopdet/PhotonPropagation/NeedsTensorflow/PhotonVisibilityExport.fcl
@@ -10,29 +10,46 @@ standard_photovisexport:
    voxel_dx:                      "10.00" # voxel x mesh step (in cm)
    voxel_dy:                      "10.00" # voxel y mesh step (in cm)
    voxel_dz:                      "10.00" # voxel z mesh step (in cm)
-   vis_model:            "semianalytical" # visibility model to be used
-                                          # (pick one between "semianalytical", "compgraph")
    n_vis_samplings:               "5"     # nr of visibility samplings inside the voxel (min 1)
-   do_refl:                  @local::dunefd_pdfastsim_par_ar_refl.DoReflectedLight
-   do_include_anode_refl:    false
-   vuvhitspars:              @local::dunefd_pdfastsim_par_ar.VUVHits
-   vishitspars:              @local::dunefd_pdfastsim_par_ar_refl.VISHits
-   tfloaderpars:			       @local::dunevd_pdfastsim_ann_ar.TFLoaderTool
 
-   do_include_buffer:        true   # include buffer region using the PhotonVisibilityService
+   tpc_vis_model: {
+      model_type: "semianalytical" # visibility model to be used
+                                   # (pick one between "semianalytical", "compgraph")
+      settings: {
+        do_refl:                  @local::dunefd_pdfastsim_par_ar_refl.DoReflectedLight
+        do_include_anode_refl:    false
+        vuvhitspars:              @local::dunefd_pdfastsim_par_ar.VUVHits
+        vishitspars:              @local::dunefd_pdfastsim_par_ar_refl.VISHits
+      }
+      #   model_type:        "compgraph" #
+      #   settings : {
+      #     tfloaderpars:			       @local::dunevd_pdfastsim_ann_ar.TFLoaderTool
+      #   }
+   }      
+   do_include_buffer:        true   # include buffer region 
+
+   buf_vis_model: {
+    model_type: "photonlibrary"
+    settings: {}
+    #  model_type: "compgraph"
+    #  settings: {
+    #    tfloaderpars: @local::dunevd_pdfastsim_ann_ar.TFLoaderTool
+    #  }
+
+   }
 }
 
 photovisexport_fdhd: @local::standard_photovisexport
 
 photovisexport_fdvd_ar: @local::standard_photovisexport
-photovisexport_fdvd_ar.vuvhitspars: @local::dunevd_pdfastsim_par_ar.VUVHits
-photovisexport_fdvd_ar.do_refl: @local::dunevd_pdfastsim_par_ar.DoReflectedLight
-photovisexport_fdvd_ar.do_include_anode_refl: @local::dunevd_pdfastsim_par_ar.IncludeAnodeReflections
+photovisexport_fdvd_ar.tpc_vis_model.vuvhitspars: @local::dunevd_pdfastsim_par_ar.VUVHits
+photovisexport_fdvd_ar.tpc_vis_model.do_refl: @local::dunevd_pdfastsim_par_ar.DoReflectedLight
+photovisexport_fdvd_ar.tpc_vis_model.do_include_anode_refl: @local::dunevd_pdfastsim_par_ar.IncludeAnodeReflections
 
 photovisexport_fdvd_xe: @local::standard_photovisexport
-photovisexport_fdvd_xe.vuvhitspars: @local::dunevd_pdfastsim_par_xe.VUVHits
-photovisexport_fdvd_xe.do_refl: @local::dunevd_pdfastsim_par_xe.DoReflectedLight
-photovisexport_fdvd_xe.do_include_anode_refl: @local::dunevd_pdfastsim_par_xe.IncludeAnodeReflections
+photovisexport_fdvd_xe.tpc_vis_model.vuvhitspars: @local::dunevd_pdfastsim_par_xe.VUVHits
+photovisexport_fdvd_xe.tpc_vis_model.do_refl: @local::dunevd_pdfastsim_par_xe.DoReflectedLight
+photovisexport_fdvd_xe.tpc_vis_model.do_include_anode_refl: @local::dunevd_pdfastsim_par_xe.IncludeAnodeReflections
 
 END_PROLOG
 

--- a/duneopdet/PhotonPropagation/NeedsTensorflow/PhotonVisibilityExport.fcl
+++ b/duneopdet/PhotonPropagation/NeedsTensorflow/PhotonVisibilityExport.fcl
@@ -45,14 +45,14 @@ photovisexport_fdhd.buf_vis_model.model_type: "photonlibrary"
 photovisexport_fdhd.buf_vis_model.settings: {}
 
 photovisexport_fdvd_ar: @local::photovisexport_fdhd
-photovisexport_fdvd_ar.tpc_vis_model.vuvhitspars: @local::dunevd_pdfastsim_par_ar.VUVHits
-photovisexport_fdvd_ar.tpc_vis_model.do_refl: @local::dunevd_pdfastsim_par_ar.DoReflectedLight
-photovisexport_fdvd_ar.tpc_vis_model.do_include_anode_refl: @local::dunevd_pdfastsim_par_ar.IncludeAnodeReflections
+photovisexport_fdvd_ar.tpc_vis_model.settings.vuvhitspars: @local::dunevd_pdfastsim_par_ar.VUVHits
+photovisexport_fdvd_ar.tpc_vis_model.settings.do_refl: @local::dunevd_pdfastsim_par_ar.DoReflectedLight
+photovisexport_fdvd_ar.tpc_vis_model.settings.do_include_anode_refl: @local::dunevd_pdfastsim_par_ar.IncludeAnodeReflections
 
 photovisexport_fdvd_xe: @local::photovisexport_fdhd
-photovisexport_fdvd_xe.tpc_vis_model.vuvhitspars: @local::dunevd_pdfastsim_par_xe.VUVHits
-photovisexport_fdvd_xe.tpc_vis_model.do_refl: @local::dunevd_pdfastsim_par_xe.DoReflectedLight
-photovisexport_fdvd_xe.tpc_vis_model.do_include_anode_refl: @local::dunevd_pdfastsim_par_xe.IncludeAnodeReflections
+photovisexport_fdvd_xe.tpc_vis_model.settings.vuvhitspars: @local::dunevd_pdfastsim_par_xe.VUVHits
+photovisexport_fdvd_xe.tpc_vis_model.settings.do_refl: @local::dunevd_pdfastsim_par_xe.DoReflectedLight
+photovisexport_fdvd_xe.tpc_vis_model.settings.do_include_anode_refl: @local::dunevd_pdfastsim_par_xe.IncludeAnodeReflections
 
 END_PROLOG
 

--- a/duneopdet/PhotonPropagation/VisibilityMapTools/fcl/lightmap_dune_fdhd_1x2x6.fcl
+++ b/duneopdet/PhotonPropagation/VisibilityMapTools/fcl/lightmap_dune_fdhd_1x2x6.fcl
@@ -20,14 +20,6 @@ services:
 ### Use the 1x2x6 geometry ###
 services.Geometry: @local::dune10kt_1x2x6_refactored_geo
 
-source:
-{
-  module_type: RootInput
-  fileNames : ["dunevis_hd_1x2x6_source.root"]
-  maxEvents:   1
-}
-
-
 physics:
 {
    analyzers:

--- a/duneopdet/PhotonPropagation/VisibilityMapTools/fcl/lightmap_dune_fdvd_1x8x14_ar.fcl
+++ b/duneopdet/PhotonPropagation/VisibilityMapTools/fcl/lightmap_dune_fdvd_1x8x14_ar.fcl
@@ -19,14 +19,6 @@ services:
 ### Use the appropriate geometry ###
 services.Geometry: @local::dunevd10kt_1x8x14_3view_30deg_v5_geo
 
-source:
-{
-  module_type: RootInput
-  fileNames : ["dunevis_vd_1x8x14_source.root"]
-  maxEvents:   1
-}
-
-
 physics:
 {
    analyzers:

--- a/duneopdet/PhotonPropagation/VisibilityMapTools/fcl/lightmap_dune_fdvd_1x8x14_xe.fcl
+++ b/duneopdet/PhotonPropagation/VisibilityMapTools/fcl/lightmap_dune_fdvd_1x8x14_xe.fcl
@@ -21,14 +21,6 @@ services.Geometry: @local::dunevd10kt_1x8x14_3view_30deg_v5_geo
 ### Setup the visibility service for Xe
 services.PhotonVisibilityService: @local::dune10kt_vd_photonvisibilityservice_Xe # changing to the xenon libaray. 
 
-source:
-{
-  module_type: RootInput
-  fileNames : ["dunevis_vd_1x8x14_source.root"]
-  maxEvents:   1
-}
-
-
 physics:
 {
    analyzers:


### PR DESCRIPTION
The module now includes a common interface to the different visibility models available (semianalytical, computable graph, photon library). This makes it possible to configure at runtime the "visibility model" for the buffer region and for the TPC active volume.
The module has been tested on the FD-HD, FD-VD (Ar), ProtoDUNE-VD geometries with different conbination of visibility models for TPC and buffer volumes (computable graph-computable-graph, semianalytical-photon library).

Because of the very different configuration needs of the visibility models I could not implement an adequate validation strategy for the fhicl configuration.  