### PR TITLE
Fix deconv filter

### DIFF
--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
@@ -13,7 +13,7 @@ WfmWienerfilter: {
 
 WfmGaussfilter: {
     Name: "Gauss"
-    Cutoff: 0.13     # In MHz.The cutoff frequency is defined by the standard deviation in the frequency domain.
+    Cutoff: 1.8      # In MHz.The cutoff frequency is defined by the standard deviation in the frequency domain.
 }                    # The cutoff value should be changed if signal smoothing is not observed.
 
 ###################################################################

--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution.fcl
@@ -58,9 +58,6 @@ generic_dune_deconvolution:
   WfmPostfilter: @local::WfmGaussfilter  # Only available "Gauss" postfilter.
 }
 
-#Postfilter Cutoff
-dune_deconvolution.WfmPostfilter.Cutoff: 1.8     # Use this value only for postfilter.
-
 
 # For backwards compatibility. This table is currently used in many workflows for different detectors, data and MC.
 dune_deconvolution: @local::generic_dune_deconvolution

--- a/duneopdet/OpticalDetector/Deconvolution/Deconvolution_module.cc
+++ b/duneopdet/OpticalDetector/Deconvolution/Deconvolution_module.cc
@@ -611,8 +611,7 @@ namespace opdet {
       // Compute filters.
       //******************************
 
-      Double_t fFrequencyCutOff = fFilterConfig.fCutoff;
-      Double_t fTickCutOff = fSamples*fFrequencyCutOff/fSampleFreq;
+      Double_t fFrequencyCutOff = fFilterConfig.fCutoff/sqrt(log(2));
 
       for (int i=0; i<(fSamples/2+1); i++) {
 
@@ -631,7 +630,7 @@ namespace opdet {
           // Compute gauss filter
           xG.fCmplx[0] = TComplex(0,0);
           xG.fCmplx.at(i) = TComplex::Exp(
-            -0.5*TMath::Power(i*fSampleFreq/(fSamples*fTickCutOff),2))
+            -0.5*TMath::Power(i*fSampleFreq/(fSamples*fFrequencyCutOff),2))
             /xH.fCmplx.at(i);
         }
 


### PR DESCRIPTION
@maridelg  and I found this problem in the deconvolution filter: 

The unity of `fTrickCutOff` is being used wrong. 

Giving a close look: 
```
Double_t fTickCutOff = fSamples*fFrequencyCutOff/fSampleFreq;
```
would give us `fTickCutOff` in `ticks` (therefore the name)

However, the operation done:
```
 xG.fCmplx.at(i) = TComplex::Exp(
            -0.5*TMath::Power(i*fSampleFreq/(fSamples*fTickCutOff),2))
```
Have `i` in ticks, `fSampleFreq` in MHz, `fSample` in  ticks. And so, the resulting unity inside the power is MHz/tick, which is incorrect (as this is inside an Exp)

With the applied changes:
`fFrequencyCutOff` remains as MHz and the power has no unity. 

Besides, we also correct the value in the fcl file from `0.13` to `1.8`, so it is now properly in MHz. 

PS.: one can make a quick check to see that the filtering will be same: 
**Before**
```
fTickCutOff = 0.13 x 1000 / 62.5 ~ 2.08 
```
**Now**
```
fFrequencyCutOff = 1.8/sqrt(log(2)) ~ 2.16 
```

The correction sqrt(log(2)) is used so the filter attenuates to 1/sqrt(2) (-3dB) in the chosen cutoff frequency.
If you want it to be exactly as before, use 1.7317 MHz 




