### PR TITLE
Fix for VD flash finder

### DIFF
--- a/duneopdet/OpticalDetector/OpFlashFinderVerticalDrift.fcl
+++ b/duneopdet/OpticalDetector/OpFlashFinderVerticalDrift.fcl
@@ -15,6 +15,4 @@ dunefdvd_opflash:
    MMdz:                 1500.0 # dist. criteria for neighbouring hits on membrane planes (cm) 
 }
 
-
-
 END_PROLOG

--- a/duneopdet/OpticalDetector/OpFlashFinderVerticalDrift_module.cc
+++ b/duneopdet/OpticalDetector/OpFlashFinderVerticalDrift_module.cc
@@ -443,7 +443,7 @@ namespace opdet {
      if(!processed[h])
      {
        auto const xyz_h = wireReadout->OpDetGeoFromOpChannel(HitVector[sorted[h]].OpChannel()).GetCenter();
-       std::cout << "Next:    " << HitVector[sorted[h]].PeakTime() << " "<< xyz_h.X() << " " << xyz_h.Y() << " " << xyz_h.Z() << std::endl; 
+      // std::cout << "Next:    " << HitVector[sorted[h]].PeakTime() << " "<< xyz_h.X() << " " << xyz_h.Y() << " " << xyz_h.Z() << std::endl; 
        dx  = (xyz_h - xyz_hitnumber).X();
        dy  = (xyz_h - xyz_hitnumber).Y();
        dz  = (xyz_h - xyz_hitnumber).Z();


### PR DESCRIPTION
Cleaning up + fix in the VD flash finder fcl (run complained of nested prolog due to extra lines).