### PR TITLE
Fix: Clang compatibility issues got fixed.

### DIFF
--- a/duneopdet/PhotonPropagation/ScintTimeTools/ScintTimeXeDoping2.h
+++ b/duneopdet/PhotonPropagation/ScintTimeTools/ScintTimeXeDoping2.h
@@ -15,7 +15,7 @@ namespace phot
     {
     public:
         explicit ScintTimeXeDoping2(fhicl::ParameterSet const& pset);
-        void GenScintTime(bool is_fast, CLHEP::HepRandomEngine& engine)  ;
+        void GenScintTime(bool is_fast, CLHEP::HepRandomEngine& engine) override;
         double fastScintTime() override;
         double slowScintTime() override;
 

--- a/duneopdet/PhotonPropagation/ScintTimeTools/ScintTimeXeDoping2_tool.cc
+++ b/duneopdet/PhotonPropagation/ScintTimeTools/ScintTimeXeDoping2_tool.cc
@@ -48,7 +48,15 @@ namespace phot
             << "  TauN2ArXe:           " << fTauN2ArXe << " ns\n"
             << "Calculated:" << "\n"
             << "  TauTA triplet:   " << fTauTA << " ns\n"
-            << "  TauTX:           " << fTauTX  << " ns\n";
+            << "  TauTX:           " << fTauTX  << " ns\n"
+            << "  fMaxProbs:       " << fMaxProbs << " \n"
+            << "  fMaxProbt:       " << fMaxProbt << " \n"
+            << "  fMaxTs:          " << fMaxTs << " ns\n"
+            << "  fMaxTt:          " << fMaxTt << " ns\n"
+            << "  FRTime:          " << FRTime << " ns\n"
+            << "  FDTime:          " << FDTime << " ns\n"
+            << "  SRTime:          " << SRTime << " ns\n"
+            << "  SDTime:          " << SDTime << " ns\n";
     }
             
     //......................................................................    


### PR DESCRIPTION
 Two errors are fixed: (1) unused private field error and (2)missing override keyword error. Added simple logging lines in ScintTimeXeDoping2 constructor to fix (1). Added override keyword at the function declaration of ScintTimeXeDoping2::GetScintTime()