### PR TITLE
adjust makefile due to library now moved to dunecore -- specifically pick up the one in duneprototypes

### DIFF
--- a/duneopdet/OpticalDetector/CMakeLists.txt
+++ b/duneopdet/OpticalDetector/CMakeLists.txt
@@ -24,8 +24,6 @@ art_make( BASENAME_ONLY ALLOW_UNDERSCORES
                                 cetlib::cetlib 
 				cetlib_except::cetlib_except 
                                 Boost::filesystem
-                                duneprototypes::Protodune_vd_ChannelMap
-                                opdet_PDVDPDMapAlg
 
   
                 MODULE_LIBRARIES
@@ -62,8 +60,8 @@ art_make( BASENAME_ONLY ALLOW_UNDERSCORES
 				CLHEP::CLHEP
                                 Boost::filesystem
                                 FFTW3::FFTW3
-                                duneprototypes::Protodune_vd_ChannelMap
-                                opdet_PDVDPDMapAlg
+				nlohmann_json::nlohmann_json
+				duneprototypes::opdet_PDVDPDMapAlg
 
                 SERVICE_LIBRARIES
                                 larcorealg::Geometry


### PR DESCRIPTION
This PR is a temporary fix to a makefile in duneopdet.  Sadly, duneopdet now depends on duneprototypes, but in the UPS dependency tree, the dependency goes the other way.  We may have to fix this at a later point, by moving the PDVD photon detector map into dunecore.  The Geometry functions in dunecore also refer to the PDVD channel map. 

But nonetheless, this PR in duneprototypes

https://github.com/DUNE/duneprototypes/pull/91

made the library Protodune_vd_ChannelMap go away.  It was used as a hint to find opdet_PDVDPDMapAlg, though it wasn't actually needed to be linked here.  Instead, opdet_PDVDPDMapAlg is now pointed explicitly in duneprototypes.  

I also found that nlohmann_json's header couldn't be found unless I added its link target.

A future PR will move the PDVD map into dunecore.