### PR TITLE
Add pdvd v5 comp graph module configuration

### DIFF
--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -279,4 +279,21 @@ protodune_vd_pdfastsim_ann_ar:                          @local::protodune_vd_v4_
 protodune_vd_pdfastsim_ann_xe:                          @local::protodune_vd_v4_pdfastsim_ann_xe
 
 
+protodune_vd_v5_pdfastsim_ann_ar:
+{
+       #Computable graph generated for protodunevd_v5_ggd.gdml
+       module_type:         "PDFastSimANN"
+       SimulationLabel:     "IonAndScint"
+       DoSlowComponent:     true
+       ScintTimeTool:       @local::ScintTimeLAr
+       TFLoaderTool:
+       {
+           tool_type:       TFLoaderMLP
+           ModelName:       "PhotonPropagation/ComputableGraph/protodune_vd_v5_128nm_tf2.6"
+           InputsName:      ["serving_default_pos_x:0", "serving_default_pos_y:0", "serving_default_pos_z:0"]
+           OutputName:      "StatefulPartitionedCall:0"
+       }
+}
+
+
 END_PROLOG


### PR DESCRIPTION
The new protoDUNE-VD v5 computable graph module configuration relies on the folder "protodune_vd_v5_128nm_tf2.6" located at "/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash/PhotonPropagation/ComputableGraph". I will create a ticket shortly after this PR, so that the module can be put in the correct location.