### PR TITLE
New PDVD Xe comp graph config

### DIFF
--- a/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
+++ b/duneopdet/PhotonPropagation/PDFastSim_dune.fcl
@@ -337,12 +337,14 @@ protodune_vd_v5_pdfastsim_ann_ar:
        }
 }
 
+protodune_vd_v5_pdfastsim_ann_xe:                          @local::protodune_vd_v5_pdfastsim_ann_ar
+protodune_vd_v5_pdfastsim_ann_xe.ScintTimeTool:            @local::ScintTimeXeDoping10ppm
+protodune_vd_v5_pdfastsim_ann_xe.TFLoaderTool.ModelName:   "PhotonPropagation/ComputableGraph/protodune_vd_v5_175nm_tf2.6"
+
 
 #Official PDVD ANN fast sim
 protodune_vd_pdfastsim_ann_ar:                          @local::protodune_vd_v5_pdfastsim_ann_ar
-#NOTE: ONE SHOULD NOT RUN DIFFERENT VERSIONS OF THE COMPGRAPH TOGETHER AND THERE IS CURRENTLY A MISMATCH BETWEEN AR AND XE DEFAULT SETTINGS.
-#IF YOU NEED TO RUN XE DOPING SIM, PLEASE CONTACT LAURA PAULUCCI FOR INSTRUCTIONS.
-protodune_vd_pdfastsim_ann_xe:                          @local::protodune_vd_v4_pdfastsim_ann_xe
+protodune_vd_pdfastsim_ann_xe:                          @local::protodune_vd_v5_pdfastsim_ann_xe
 
 
 END_PROLOG


### PR DESCRIPTION
This PR includes the computable graph configuration at 175 nm (xenon main component) for ProtoDUNE-VD trained by Shuaixiang Zang and Fenosoa Fanomezana with version 5 of the geometry.