### PR TITLE
Update to RawWaveformAna module - wfm and trigger timestamps

### DIFF
--- a/duneopdet/OpticalDetector/Ana/RawWaveformAna.fcl
+++ b/duneopdet/OpticalDetector/Ana/RawWaveformAna.fcl
@@ -3,16 +3,19 @@ BEGIN_PROLOG
 rawwaveform_ana: {
    module_type: "RawWaveformAna"
    TriggerModule: "triggerrawdecoder:daq"
+   TriggerDataFormat: ""
 }
 
 
 protodunevd_rawwaveform_ana: {
    @table::rawwaveform_ana
    InputModule: "pdvddaphne:daq"
+   TriggerDataFormat: "PDVD"
 }
 protodunehd_rawwaveform_ana: {
    @table::rawwaveform_ana
    InputModule: "pdhddaphne:daq"
+   TriggerDataFormat: "PDHD"
 }
 
 

--- a/duneopdet/OpticalDetector/Ana/RawWaveformAna_module.cc
+++ b/duneopdet/OpticalDetector/Ana/RawWaveformAna_module.cc
@@ -70,14 +70,16 @@ namespace opdet {
         int Run;
         int SubRun;
         int Event;
-        uint64_t TimeStamp;
+        uint64_t TimeStamp_uint64;
+        double TimeStamp_double;
         int OpChannel;
         unsigned int nSamples;
         //double SampleSize;
         std::vector<short> adc_value;
         //unsigned int nOpDet;
         unsigned int TriggerType;
-
+        uint64_t TriggerTime_uint64;
+        double TriggerTime_double;
     };
 }
 
@@ -103,7 +105,10 @@ namespace opdet {
         fWaveformTree->Branch("SubRun"    , &SubRun    , "SubRun/I"    );
         fWaveformTree->Branch("Event"     , &Event     , "Event/I"     );
         fWaveformTree->Branch("Trigger"     , &TriggerType     , "Trigger/I"     );
-        fWaveformTree->Branch("TimeStamp" , &TimeStamp     , "TimeStamp/l"     );
+        fWaveformTree->Branch("TriggerTime_uint64" , &TriggerTime_uint64, "TriggerTime_uint64/l" );
+        fWaveformTree->Branch("TriggerTime_double" , &TriggerTime_double, "TriggerTime_double/D" );
+        fWaveformTree->Branch("TimeStamp_uint64" , &TimeStamp_uint64     , "TimeStamp_uint64/l"     );
+        fWaveformTree->Branch("TimeStamp_double" , &TimeStamp_double     , "TimeStamp_double/D"     );
         fWaveformTree->Branch("NSamples"     , &nSamples     , "NSamples/I"     );
         fWaveformTree->Branch("OpChannel"     , &OpChannel     , "OpChannel/I"     );
         fWaveformTree->Branch("adc", &adc_value);
@@ -136,11 +141,16 @@ namespace opdet {
         SubRun = evt.id().subRun();
         Event = evt.id().event();
         TriggerType = (unsigned int)trig.type;
+        // TriggerCandidateData::time_candidate ... time of the trigger signal?
+        // TriggerCandidateData::time_start ... time of the DAQ window opened?
+        TriggerTime_uint64 = trig.time_candidate; // in ticks (16 ns, time system clock) since epoch
+        TriggerTime_double = (double)trig.time_candidate;
 
         for (auto &wfm: *wfmHndl) {
             OpChannel = wfm.ChannelNumber();
             nSamples  = wfm.Waveform().size();
-            TimeStamp = (uint64_t)wfm.TimeStamp();
+            TimeStamp_uint64 = (uint64_t)wfm.TimeStamp();
+            TimeStamp_double = wfm.TimeStamp(); // was in ticks (16 ns, PDS clock), now custom fix to microseconds
             adc_value.resize(nSamples);
 
             for (unsigned int ii = 0; ii< nSamples ; ii++) {

--- a/duneopdet/OpticalDetector/Ana/RawWaveformAna_module.cc
+++ b/duneopdet/OpticalDetector/Ana/RawWaveformAna_module.cc
@@ -151,8 +151,14 @@ namespace opdet {
         for (auto &wfm: *wfmHndl) {
             OpChannel = wfm.ChannelNumber();
             nSamples  = wfm.Waveform().size();
+
+            // Waveform timestamp convetion is dependending on the decoder.
+            // For PD HD and VD, the decoder stored this in ticks (16 ns, PDS clock) since the epoch. However, the type double cannot hold its precision.
+            // The latest fix to the PD VD digitizer trims the original raw timestamp (uint64) to 40 least significant bits and converts it to a double in microseconds.
+            // The uint64 form here stays for backward compatibility. Use the double version if the time stamp is in microseconds.
             TimeStamp_uint64 = (uint64_t)wfm.TimeStamp();
-            TimeStamp_double = wfm.TimeStamp(); // was in ticks (16 ns, PDS clock), now custom fix to microseconds
+            TimeStamp_double = wfm.TimeStamp(); 
+            
             adc_value.resize(nSamples);
 
             for (unsigned int ii = 0; ii< nSamples ; ii++) {

--- a/duneopdet/OpticalDetector/Ana/protodunehd_rawwaveformana_run.fcl
+++ b/duneopdet/OpticalDetector/Ana/protodunehd_rawwaveformana_run.fcl
@@ -1,0 +1,58 @@
+#include "HDF5RawInput3.fcl"
+
+#include "opticaldetectormodules_dune.fcl"
+#include "services_protodunehd.fcl"
+#include "PDHDTriggerReader3.fcl"
+#include "DAPHNEReaderPDHD.fcl"
+
+#include "RawWaveformAna.fcl"
+
+process_name: RawWaveformAna
+
+services:
+{
+   # Load the service that manages root files for histograms.
+   TFileService: { fileName: "%ifb_ana.root" }
+
+   TimeTracker:       {}
+   MemoryTracker:     {}
+   RandomNumberGenerator: {} #ART native random number generator
+
+   @table::protodunehd_reco_services
+
+   DetectorPropertiesService:  @local::protodunehd_detproperties
+
+   HDF5RawFile3Service:  {}
+
+}
+
+source: @local::hdf5rawinput3
+
+outputs: {}
+
+physics: {
+   producers: {
+      rns:            { module_type: "RandomNumberSaver" }
+      triggerrawdecoder:@local::PDHDTriggerReader3Defaults
+      pdhddaphne: @local::DAPHNEReaderPDHD
+   }
+
+
+   analyzers: {
+      rawwfmana: @local::protodunehd_rawwaveform_ana
+   }
+
+   produce: [ rns,triggerrawdecoder,pdhddaphne ]
+   analyze:  [ rawwfmana ]
+
+   #trigger_paths is a keyword and contains the paths that modify the art::event, ie filters and producers
+   trigger_paths: [ produce ]
+
+   #end_paths is a keyword and contains the paths that do not modify the art::Event,
+   #ie analyzers and output streams.  these all run simultaneously
+   end_paths:     [ analyze ]
+}
+
+
+# physics.producers.pdhddaphne.DAPHNEInterface: { tool_type: "DAPHNEInterface2" }
+physics.producers.pdhddaphne.ExportWaveformTree: false


### PR DESCRIPTION
This PR includes timestamps in two types - double and uint64. Trigger timestamp is read and stored. Trigger info can now be read for PD HD or VD. 